### PR TITLE
feat: environments, user model

### DIFF
--- a/lib/config/dependencies.dart
+++ b/lib/config/dependencies.dart
@@ -6,6 +6,8 @@ import '../data/services/api/auth_api_client.dart';
 import '../data/services/shared_preferences_service.dart';
 import '../data/repositories/auth/auth_repository.dart';
 import '../data/repositories/auth/auth_repository_remote.dart';
+import '../data/repositories/environment/environment.dart';
+import '../data/repositories/environment/environment_remote.dart';
 
 /// Shared providers for all configurations.
 List<SingleChildWidget> _sharedProviders = [
@@ -18,13 +20,26 @@ List<SingleChildWidget> get providersRemote {
     Provider(create: (context) => ApiClient()),
     Provider(create: (context) => SharedPreferencesService()),
     ChangeNotifierProvider(
-      create: (context) =>
-          AuthRepositoryRemote(
-                authApiClient: context.read(),
-                apiClient: context.read(),
-                sharedPreferencesService: context.read(),
-              )
-              as AuthRepository,
+      create: (context) {
+        final authApiClient = context.read<AuthApiClient>();
+        final apiClient = context.read<ApiClient>();
+        final sharedPreferencesService = context.read<SharedPreferencesService>();
+        final repo = AuthRepositoryRemote(
+          authApiClient: authApiClient,
+          apiClient: apiClient,
+          sharedPreferencesService: sharedPreferencesService,
+        );
+
+        // Let ApiClient call the repository to attempt a refresh when a 401 occurs
+        apiClient.authRefreshProvider = repo.refreshToken;
+
+        return repo as AuthRepository;
+      },
+    ),
+    Provider(
+      create: (context) => 
+        EnvironmentRemoteRepository(apiClient: context.read())
+          as EnvironmentRepository,
     ),
     ..._sharedProviders,
   ];

--- a/lib/data/repositories/auth/auth_repository.dart
+++ b/lib/data/repositories/auth/auth_repository.dart
@@ -7,6 +7,10 @@ abstract class AuthRepository extends ChangeNotifier {
   /// Returns [Future] because it will load a stored auth state the first time.
   Future<bool> get isAuthenticated;
 
+  /// Try to refresh the authentication token. Returns true when refresh
+  /// succeeded and a new token is available.
+  Future<bool> refreshToken();
+
   /// Perform login
   Future<Result<void>> login({required String username, required String password});
 

--- a/lib/data/repositories/auth/auth_repository_dev.dart
+++ b/lib/data/repositories/auth/auth_repository_dev.dart
@@ -3,7 +3,15 @@ import 'auth_repository.dart';
 
 class AuthRepositoryDev extends AuthRepository {
   @override
-  Future<bool> get isAuthenticated => Future.value(true);
+  Future<bool> get isAuthenticated => Future.value(false);
+
+  @override
+  Future<bool> refreshToken() async {
+    // In dev, we don't have a refresh endpoint. Return false to indicate
+    // refresh not available. If you want auto-refresh in dev, change this
+    // to return true and set a dummy token in SharedPreferences.
+    return Future.value(false);
+  }
 
   @override
   Future<Result<void>> login({

--- a/lib/data/repositories/environment/environment.dart
+++ b/lib/data/repositories/environment/environment.dart
@@ -1,7 +1,9 @@
-import 'package:flutter/foundation.dart';
+import 'package:container_monitoring/domain/models/environment/environment_summary.dart';
+import 'package:container_monitoring/utils/result.dart';
 
-import '../../../../utils/result.dart';
 
-abstract class EnvironmentRepository extends ChangeNotifier {
-  
+abstract class EnvironmentRepository {
+  /// List all environments  
+  Future<Result<List<EnvironmentSummary>>> listEnvironments();
+
 }

--- a/lib/data/repositories/environment/environment_remote.dart
+++ b/lib/data/repositories/environment/environment_remote.dart
@@ -1,0 +1,61 @@
+import 'package:container_monitoring/data/repositories/environment/environment.dart';
+import 'package:container_monitoring/data/services/api/api_client.dart';
+import 'package:container_monitoring/data/services/api/models/environment/environment.dart';
+import 'package:container_monitoring/domain/models/environment/environment_summary.dart';
+import '../../../utils/result.dart';
+
+class EnvironmentRemoteRepository extends EnvironmentRepository {
+  EnvironmentRemoteRepository({required ApiClient apiClient})
+    : _apiClient = apiClient;
+
+  final ApiClient _apiClient;
+
+  // List<Environment>? _cachedEnvironments;
+
+  @override
+  Future<Result<List<EnvironmentSummary>>> listEnvironments() async {
+    try {
+      final result = await _apiClient.listEnvironments();
+      switch (result) {
+        case Error<List<Environment>>():
+          return Result.error(result.error);
+        case Ok<List<Environment>>():
+      }
+      final environmentsApi = result.value;
+      // _cachedEnvironments = environments;
+      return Result.ok(
+        environmentsApi
+            .map(
+              (environmentApi) => EnvironmentSummary(
+                id: environmentApi.id,
+                name: environmentApi.name,
+                type: environmentApi.type,
+                url: environmentApi.uRL,
+                status: environmentApi.status,
+                time: environmentApi.snapshots[0].time,
+                dockerVersion: environmentApi.snapshots[0].dockerVersion,
+                swarm: environmentApi.snapshots[0].swarm,
+                totalCpu: environmentApi.snapshots[0].totalCPU,
+                totalMemory: environmentApi.snapshots[0].totalMemory,
+                containerCount: environmentApi.snapshots[0].containerCount,
+                runningContainerCount:
+                    environmentApi.snapshots[0].runningContainerCount,
+                stoppedContainerCount:
+                    environmentApi.snapshots[0].stoppedContainerCount,
+                healthyContainerCount:
+                    environmentApi.snapshots[0].healthyContainerCount,
+                unhealthyContainerCount:
+                    environmentApi.snapshots[0].unhealthyContainerCount,
+                volumeCount: environmentApi.snapshots[0].volumeCount,
+                imageCount: environmentApi.snapshots[0].imageCount,
+                serviceCount: environmentApi.snapshots[0].serviceCount,
+                stackCount: environmentApi.snapshots[0].stackCount,
+              ),
+            )
+            .toList(),
+      );
+    } on Exception catch (error) {
+      return Result.error(error);
+    }
+  }
+}

--- a/lib/data/services/api/api_client.dart
+++ b/lib/data/services/api/api_client.dart
@@ -1,27 +1,118 @@
 import 'dart:io';
+import 'dart:convert';
+
+import 'package:container_monitoring/data/services/api/models/environment/environment.dart';
+import 'package:container_monitoring/data/services/api/models/user/user_api_model.dart';
+import 'package:container_monitoring/utils/result.dart';
 
 typedef AuthHeaderProvider = String? Function();
+typedef AuthRefreshProvider = Future<bool> Function();
 
 class ApiClient {
-  ApiClient({String? baseUrl, int? port, HttpClient Function()? clientFactory})
+  ApiClient({String? baseUrl, HttpClient Function()? clientFactory})
     : _baseUrl = baseUrl ?? 'localhost',
-      _port = port ?? 8080,
       _clientFactory = clientFactory ?? (() => HttpClient());
 
   final String _baseUrl;
-  final int _port;
   final HttpClient Function() _clientFactory;
 
   AuthHeaderProvider? _authHeaderProvider;
+  AuthRefreshProvider? _authRefreshProvider;
 
   set authHeaderProvider(AuthHeaderProvider? provider) {
     _authHeaderProvider = provider;
+  }
+
+  set authRefreshProvider(AuthRefreshProvider? provider) {
+    _authRefreshProvider = provider;
   }
 
   Future<void> _authHeader(HttpHeaders headers) async {
     final header = _authHeaderProvider?.call();
     if (header != null) {
       headers.set(HttpHeaders.authorizationHeader, header);
+    }
+  }
+
+  Future<Result<UserApiModel>> getUser() async {
+    final client = _clientFactory();
+    try {
+      final uri = Uri(scheme: 'https', host: _baseUrl, path: '/api/users/me');
+      final request = await client.getUrl(uri);
+      await _authHeader(request.headers);
+      final response = await request.close();
+      // If unauthorized, try refresh once and retry
+      if (response.statusCode == 401 && _authRefreshProvider != null) {
+        client.close(force: true);
+        final refreshed = await _authRefreshProvider!.call();
+        if (refreshed) {
+          final client2 = _clientFactory();
+          final request2 = await client2.getUrl(uri);
+          await _authHeader(request2.headers);
+          final response2 = await request2.close();
+          if (response2.statusCode == 200) {
+            final respBody = await response2.transform(utf8.decoder).join();
+            final Map<String, dynamic> data = jsonDecode(respBody);
+            return Result.ok(UserApiModel.fromJson(data));
+          } else {
+            return const Result.error(HttpException('Failed to get user'));
+          }
+        }
+      }
+      if (response.statusCode == 200) {
+        final respBody = await response.transform(utf8.decoder).join();
+        final Map<String, dynamic> data = jsonDecode(respBody);
+        return Result.ok(UserApiModel.fromJson(data));
+      } else {
+        return const Result.error(HttpException('Failed to get user'));
+      }
+    } on Exception catch (error) {
+      return Result.error(error);
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  Future<Result<List<Environment>>> listEnvironments() async {
+    final client = _clientFactory();
+    try {
+      final uri = Uri(scheme: 'https', host: _baseUrl, path: '/api/endpoints');
+      final request = await client.getUrl(uri);
+      await _authHeader(request.headers);
+      final response = await request.close();
+      // If unauthorized, try refresh once and retry
+      if (response.statusCode == 401 && _authRefreshProvider != null) {
+        client.close(force: true);
+        final refreshed = await _authRefreshProvider!.call();
+        if (refreshed) {
+          final client2 = _clientFactory();
+          final request2 = await client2.getUrl(uri);
+          await _authHeader(request2.headers);
+          final response2 = await request2.close();
+          if (response2.statusCode == 200) {
+            final respBody = await response2.transform(utf8.decoder).join();
+            final List<dynamic> data = jsonDecode(respBody);
+            final environments = data.map((e) => Environment.fromJson(e)).toList();
+            return Result.ok(environments);
+          } else {
+            return const Result.error(HttpException('Failed to list environments'));
+          }
+        }
+      }
+      if (response.statusCode == 200) {
+        final respBody = await response.transform(utf8.decoder).join();
+        final List<dynamic> data = jsonDecode(respBody);
+        final environments = data.map((e) => Environment.fromJson(e)).toList();
+        return Result.ok(environments);
+      } else {
+        return const Result.error(
+          HttpException('Failed to list environments'),
+        );
+      }
+    } on Exception catch (error) {
+      return Result.error(error);
+    } finally {
+      client.close(force: true);
     }
   }
 }

--- a/lib/data/services/api/models/environment/environment.dart
+++ b/lib/data/services/api/models/environment/environment.dart
@@ -5,53 +5,58 @@ part 'environment.g.dart';
 
 @freezed
 abstract class Environment with _$Environment {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory Environment({
     required int id,
     required String name,
     required int type,
-    required String containerEngine,
-    required String url,
+    String? containerEngine,
+    required String uRL,
     required int groupId,
-    required String publicUrl,
-    required List<String> gpus,
-    required TLSConfig tlsConfig,
+    String? publicUrl,
+    List<String>? gpus,
+    TLSConfig? tlsConfig,
     required AzureCredentials azureCredentials,
-    required List<int> tagIds,
+    List<int>? tagIds,
     required int status,
     required List<Snapshot> snapshots,
   }) = _Environment;
 
-  factory Environment.fromJson(Map<String, dynamic> json) => _$EnvironmentFromJson(json);
+  factory Environment.fromJson(Map<String, dynamic> json) =>
+      _$EnvironmentFromJson(json);
 }
 
 @freezed
 abstract class TLSConfig with _$TLSConfig {
-  const factory TLSConfig({
-    required bool tls,
-    required bool tlsSkipVerify,
-  }) = _TLSConfig;
+  @JsonSerializable(fieldRename: FieldRename.pascal)
+  const factory TLSConfig({required bool tls, required bool tlsSkipVerify}) =
+      _TLSConfig;
 
-  factory TLSConfig.fromJson(Map<String, dynamic> json) => _$TLSConfigFromJson(json);
+  factory TLSConfig.fromJson(Map<String, dynamic> json) =>
+      _$TLSConfigFromJson(json);
 }
 
 @freezed
 abstract class AzureCredentials with _$AzureCredentials {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory AzureCredentials({
-    required String applicationId,
-    required String tenantId,
-    required String authenticationKey,
+    String? applicationID,
+    String? tenantID,
+    String? authenticationKey,
   }) = _AzureCredentials;
 
-  factory AzureCredentials.fromJson(Map<String, dynamic> json) => _$AzureCredentialsFromJson(json);
+  factory AzureCredentials.fromJson(Map<String, dynamic> json) =>
+      _$AzureCredentialsFromJson(json);
 }
 
 @freezed
 abstract class Snapshot with _$Snapshot {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory Snapshot({
     required int time,
     required String dockerVersion,
     required bool swarm,
-    required int totalCpu,
+    required int totalCPU,
     required int totalMemory,
     required int containerCount,
     required int runningContainerCount,
@@ -65,11 +70,13 @@ abstract class Snapshot with _$Snapshot {
     required DockerSnapshotRaw dockerSnapshotRaw,
   }) = _Snapshot;
 
-  factory Snapshot.fromJson(Map<String, dynamic> json) => _$SnapshotFromJson(json);
+  factory Snapshot.fromJson(Map<String, dynamic> json) =>
+      _$SnapshotFromJson(json);
 }
 
 @freezed
 abstract class DockerSnapshotRaw with _$DockerSnapshotRaw {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory DockerSnapshotRaw({
     required List<ContainerInfo> containers,
     required VolumeData volumes,
@@ -79,16 +86,18 @@ abstract class DockerSnapshotRaw with _$DockerSnapshotRaw {
     required DockerVersionInfo version,
   }) = _DockerSnapshotRaw;
 
-  factory DockerSnapshotRaw.fromJson(Map<String, dynamic> json) => _$DockerSnapshotRawFromJson(json);
+  factory DockerSnapshotRaw.fromJson(Map<String, dynamic> json) =>
+      _$DockerSnapshotRawFromJson(json);
 }
 
 @freezed
 abstract class ContainerInfo with _$ContainerInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory ContainerInfo({
     required String id,
     required List<String> names,
     required String image,
-    required String imageId,
+    required String imageID,
     required String command,
     required int created,
     required List<PortInfo> ports,
@@ -100,11 +109,13 @@ abstract class ContainerInfo with _$ContainerInfo {
     required List<MountInfo> mounts,
   }) = _ContainerInfo;
 
-  factory ContainerInfo.fromJson(Map<String, dynamic> json) => _$ContainerInfoFromJson(json);
+  factory ContainerInfo.fromJson(Map<String, dynamic> json) =>
+      _$ContainerInfoFromJson(json);
 }
 
 @freezed
 abstract class PortInfo with _$PortInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory PortInfo({
     String? ip,
     required int privatePort,
@@ -112,51 +123,57 @@ abstract class PortInfo with _$PortInfo {
     required String type,
   }) = _PortInfo;
 
-  factory PortInfo.fromJson(Map<String, dynamic> json) => _$PortInfoFromJson(json);
+  factory PortInfo.fromJson(Map<String, dynamic> json) =>
+      _$PortInfoFromJson(json);
 }
 
 @freezed
 abstract class HostConfigInfo with _$HostConfigInfo {
-  const factory HostConfigInfo({
-    required String networkMode,
-  }) = _HostConfigInfo;
+  @JsonSerializable(fieldRename: FieldRename.pascal)
+  const factory HostConfigInfo({required String networkMode}) = _HostConfigInfo;
 
-  factory HostConfigInfo.fromJson(Map<String, dynamic> json) => _$HostConfigInfoFromJson(json);
+  factory HostConfigInfo.fromJson(Map<String, dynamic> json) =>
+      _$HostConfigInfoFromJson(json);
 }
 
 @freezed
 abstract class NetworkSettingsInfo with _$NetworkSettingsInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory NetworkSettingsInfo({
     required Map<String, NetworkDetailInfo> networks,
   }) = _NetworkSettingsInfo;
 
-  factory NetworkSettingsInfo.fromJson(Map<String, dynamic> json) => _$NetworkSettingsInfoFromJson(json);
+  factory NetworkSettingsInfo.fromJson(Map<String, dynamic> json) =>
+      _$NetworkSettingsInfoFromJson(json);
 }
 
 @freezed
 abstract class NetworkDetailInfo with _$NetworkDetailInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory NetworkDetailInfo({
     dynamic ipamConfig,
     dynamic links,
     dynamic aliases,
     required String macAddress,
     dynamic driverOpts,
-    required String networkId,
-    required String endpointId,
+    required String networkID,
+    required String endpointID,
     required String gateway,
-    required String ipAddress,
-    required int ipPrefixLen,
-    required String ipv6Gateway,
-    required String globalIpv6Address,
-    required int globalIpv6PrefixLen,
+    required String iPAddress,
+    int? iPPrefixLen,
+    String? iPv6Gateway,
+    String? globalIPv6Address,
+    int? globalIPv6PrefixLen,
     dynamic dnsNames,
   }) = _NetworkDetailInfo;
 
-  factory NetworkDetailInfo.fromJson(Map<String, dynamic> json) => _$NetworkDetailInfoFromJson(json);
+  factory NetworkDetailInfo.fromJson(Map<String, dynamic> json) =>
+      _$NetworkDetailInfoFromJson(json);
 }
 
 @freezed
 abstract class MountInfo with _$MountInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory MountInfo({
     required String type,
     String? name,
@@ -164,93 +181,90 @@ abstract class MountInfo with _$MountInfo {
     required String destination,
     String? driver,
     required String mode,
-    required bool rw,
-    required String propagation,
+    required bool rW,
+    String? propagation,
   }) = _MountInfo;
 
-  factory MountInfo.fromJson(Map<String, dynamic> json) => _$MountInfoFromJson(json);
+  factory MountInfo.fromJson(Map<String, dynamic> json) =>
+      _$MountInfoFromJson(json);
 }
 
 @freezed
 abstract class VolumeData with _$VolumeData {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory VolumeData({
     required List<VolumeInfo> volumes,
     dynamic warnings,
   }) = _VolumeData;
 
-  factory VolumeData.fromJson(Map<String, dynamic> json) => _$VolumeDataFromJson(json);
+  factory VolumeData.fromJson(Map<String, dynamic> json) =>
+      _$VolumeDataFromJson(json);
 }
 
 @freezed
 abstract class VolumeInfo with _$VolumeInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory VolumeInfo({
     required String createdAt,
     required String driver,
     Map<String, String>? labels,
     required String mountpoint,
     required String name,
-    Map<String, String>? options,
     required String scope,
   }) = _VolumeInfo;
 
-  factory VolumeInfo.fromJson(Map<String, dynamic> json) => _$VolumeInfoFromJson(json);
+  factory VolumeInfo.fromJson(Map<String, dynamic> json) =>
+      _$VolumeInfoFromJson(json);
 }
 
 @freezed
 abstract class NetworkInfo with _$NetworkInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory NetworkInfo({
     required String name,
     required String id,
     required String created,
     required String scope,
     required String driver,
-    required bool enableIpv6,
-    required IPAMInfo ipam,
+    required bool enableIPv6,
     required bool internal,
     required bool attachable,
     required bool ingress,
     required ConfigFromInfo configFrom,
     required bool configOnly,
     required Map<String, dynamic> containers,
-    required Map<String, dynamic> options,
+    Map<String, dynamic>? options,
     required Map<String, dynamic> labels,
   }) = _NetworkInfo;
 
-  factory NetworkInfo.fromJson(Map<String, dynamic> json) => _$NetworkInfoFromJson(json);
-}
-
-@freezed
-abstract class IPAMInfo with _$IPAMInfo {
-  const factory IPAMInfo({
-    required String driver,
-    required Map<String, dynamic> options,
-    required List<IPAMConfigInfo> config,
-  }) = _IPAMInfo;
-
-  factory IPAMInfo.fromJson(Map<String, dynamic> json) => _$IPAMInfoFromJson(json);
+  factory NetworkInfo.fromJson(Map<String, dynamic> json) =>
+      _$NetworkInfoFromJson(json);
 }
 
 @freezed
 abstract class IPAMConfigInfo with _$IPAMConfigInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory IPAMConfigInfo({
     required String subnet,
     required String gateway,
   }) = _IPAMConfigInfo;
 
-  factory IPAMConfigInfo.fromJson(Map<String, dynamic> json) => _$IPAMConfigInfoFromJson(json);
+  factory IPAMConfigInfo.fromJson(Map<String, dynamic> json) =>
+      _$IPAMConfigInfoFromJson(json);
 }
 
 @freezed
 abstract class ConfigFromInfo with _$ConfigFromInfo {
-  const factory ConfigFromInfo({
-    required String network,
-  }) = _ConfigFromInfo;
+  @JsonSerializable(fieldRename: FieldRename.pascal)
+  const factory ConfigFromInfo({required String network}) = _ConfigFromInfo;
 
-  factory ConfigFromInfo.fromJson(Map<String, dynamic> json) => _$ConfigFromInfoFromJson(json);
+  factory ConfigFromInfo.fromJson(Map<String, dynamic> json) =>
+      _$ConfigFromInfoFromJson(json);
 }
 
 @freezed
 abstract class ImageInfo with _$ImageInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory ImageInfo({
     required int containers,
     required int created,
@@ -263,34 +277,38 @@ abstract class ImageInfo with _$ImageInfo {
     required int size,
   }) = _ImageInfo;
 
-  factory ImageInfo.fromJson(Map<String, dynamic> json) => _$ImageInfoFromJson(json);
+  factory ImageInfo.fromJson(Map<String, dynamic> json) =>
+      _$ImageInfoFromJson(json);
 }
 
 @freezed
 abstract class DockerInfo with _$DockerInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory DockerInfo({
-    required String id,
+    @JsonKey(name: "ID") required String id,
     required int containers,
     required int containersRunning,
     required int containersPaused,
     required int containersStopped,
     required int images,
     required String driver,
-    required int ncpu,
+    required int nCPU,
     required int memTotal,
     required String name,
     required String serverVersion,
   }) = _DockerInfo;
 
-  factory DockerInfo.fromJson(Map<String, dynamic> json) => _$DockerInfoFromJson(json);
+  factory DockerInfo.fromJson(Map<String, dynamic> json) =>
+      _$DockerInfoFromJson(json);
 }
 
 @freezed
 abstract class DockerVersionInfo with _$DockerVersionInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
   const factory DockerVersionInfo({
     required String version,
     required String apiVersion,
-    required String minApiVersion,
+    required String minAPIVersion,
     required String gitCommit,
     required String goVersion,
     required String os,
@@ -299,5 +317,6 @@ abstract class DockerVersionInfo with _$DockerVersionInfo {
     required String buildTime,
   }) = _DockerVersionInfo;
 
-  factory DockerVersionInfo.fromJson(Map<String, dynamic> json) => _$DockerVersionInfoFromJson(json);
+  factory DockerVersionInfo.fromJson(Map<String, dynamic> json) =>
+      _$DockerVersionInfoFromJson(json);
 }

--- a/lib/data/services/api/models/environment/environment.freezed.dart
+++ b/lib/data/services/api/models/environment/environment.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Environment {
 
- int get id; String get name; int get type; String get containerEngine; String get url; int get groupId; String get publicUrl; List<String> get gpus; TLSConfig get tlsConfig; AzureCredentials get azureCredentials; List<int> get tagIds; int get status; List<Snapshot> get snapshots;
+ int get id; String get name; int get type; String? get containerEngine; String get uRL; int get groupId; String? get publicUrl; List<String>? get gpus; TLSConfig? get tlsConfig; AzureCredentials get azureCredentials; List<int>? get tagIds; int get status; List<Snapshot> get snapshots;
 /// Create a copy of Environment
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $EnvironmentCopyWith<Environment> get copyWith => _$EnvironmentCopyWithImpl<Envi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Environment&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.containerEngine, containerEngine) || other.containerEngine == containerEngine)&&(identical(other.url, url) || other.url == url)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.publicUrl, publicUrl) || other.publicUrl == publicUrl)&&const DeepCollectionEquality().equals(other.gpus, gpus)&&(identical(other.tlsConfig, tlsConfig) || other.tlsConfig == tlsConfig)&&(identical(other.azureCredentials, azureCredentials) || other.azureCredentials == azureCredentials)&&const DeepCollectionEquality().equals(other.tagIds, tagIds)&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other.snapshots, snapshots));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Environment&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.containerEngine, containerEngine) || other.containerEngine == containerEngine)&&(identical(other.uRL, uRL) || other.uRL == uRL)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.publicUrl, publicUrl) || other.publicUrl == publicUrl)&&const DeepCollectionEquality().equals(other.gpus, gpus)&&(identical(other.tlsConfig, tlsConfig) || other.tlsConfig == tlsConfig)&&(identical(other.azureCredentials, azureCredentials) || other.azureCredentials == azureCredentials)&&const DeepCollectionEquality().equals(other.tagIds, tagIds)&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other.snapshots, snapshots));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,type,containerEngine,url,groupId,publicUrl,const DeepCollectionEquality().hash(gpus),tlsConfig,azureCredentials,const DeepCollectionEquality().hash(tagIds),status,const DeepCollectionEquality().hash(snapshots));
+int get hashCode => Object.hash(runtimeType,id,name,type,containerEngine,uRL,groupId,publicUrl,const DeepCollectionEquality().hash(gpus),tlsConfig,azureCredentials,const DeepCollectionEquality().hash(tagIds),status,const DeepCollectionEquality().hash(snapshots));
 
 @override
 String toString() {
-  return 'Environment(id: $id, name: $name, type: $type, containerEngine: $containerEngine, url: $url, groupId: $groupId, publicUrl: $publicUrl, gpus: $gpus, tlsConfig: $tlsConfig, azureCredentials: $azureCredentials, tagIds: $tagIds, status: $status, snapshots: $snapshots)';
+  return 'Environment(id: $id, name: $name, type: $type, containerEngine: $containerEngine, uRL: $uRL, groupId: $groupId, publicUrl: $publicUrl, gpus: $gpus, tlsConfig: $tlsConfig, azureCredentials: $azureCredentials, tagIds: $tagIds, status: $status, snapshots: $snapshots)';
 }
 
 
@@ -48,11 +48,11 @@ abstract mixin class $EnvironmentCopyWith<$Res>  {
   factory $EnvironmentCopyWith(Environment value, $Res Function(Environment) _then) = _$EnvironmentCopyWithImpl;
 @useResult
 $Res call({
- int id, String name, int type, String containerEngine, String url, int groupId, String publicUrl, List<String> gpus, TLSConfig tlsConfig, AzureCredentials azureCredentials, List<int> tagIds, int status, List<Snapshot> snapshots
+ int id, String name, int type, String? containerEngine, String uRL, int groupId, String? publicUrl, List<String>? gpus, TLSConfig? tlsConfig, AzureCredentials azureCredentials, List<int>? tagIds, int status, List<Snapshot> snapshots
 });
 
 
-$TLSConfigCopyWith<$Res> get tlsConfig;$AzureCredentialsCopyWith<$Res> get azureCredentials;
+$TLSConfigCopyWith<$Res>? get tlsConfig;$AzureCredentialsCopyWith<$Res> get azureCredentials;
 
 }
 /// @nodoc
@@ -65,20 +65,20 @@ class _$EnvironmentCopyWithImpl<$Res>
 
 /// Create a copy of Environment
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? containerEngine = null,Object? url = null,Object? groupId = null,Object? publicUrl = null,Object? gpus = null,Object? tlsConfig = null,Object? azureCredentials = null,Object? tagIds = null,Object? status = null,Object? snapshots = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? containerEngine = freezed,Object? uRL = null,Object? groupId = null,Object? publicUrl = freezed,Object? gpus = freezed,Object? tlsConfig = freezed,Object? azureCredentials = null,Object? tagIds = freezed,Object? status = null,Object? snapshots = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as int,containerEngine: null == containerEngine ? _self.containerEngine : containerEngine // ignore: cast_nullable_to_non_nullable
-as String,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as int,containerEngine: freezed == containerEngine ? _self.containerEngine : containerEngine // ignore: cast_nullable_to_non_nullable
+as String?,uRL: null == uRL ? _self.uRL : uRL // ignore: cast_nullable_to_non_nullable
 as String,groupId: null == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
-as int,publicUrl: null == publicUrl ? _self.publicUrl : publicUrl // ignore: cast_nullable_to_non_nullable
-as String,gpus: null == gpus ? _self.gpus : gpus // ignore: cast_nullable_to_non_nullable
-as List<String>,tlsConfig: null == tlsConfig ? _self.tlsConfig : tlsConfig // ignore: cast_nullable_to_non_nullable
-as TLSConfig,azureCredentials: null == azureCredentials ? _self.azureCredentials : azureCredentials // ignore: cast_nullable_to_non_nullable
-as AzureCredentials,tagIds: null == tagIds ? _self.tagIds : tagIds // ignore: cast_nullable_to_non_nullable
-as List<int>,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as int,publicUrl: freezed == publicUrl ? _self.publicUrl : publicUrl // ignore: cast_nullable_to_non_nullable
+as String?,gpus: freezed == gpus ? _self.gpus : gpus // ignore: cast_nullable_to_non_nullable
+as List<String>?,tlsConfig: freezed == tlsConfig ? _self.tlsConfig : tlsConfig // ignore: cast_nullable_to_non_nullable
+as TLSConfig?,azureCredentials: null == azureCredentials ? _self.azureCredentials : azureCredentials // ignore: cast_nullable_to_non_nullable
+as AzureCredentials,tagIds: freezed == tagIds ? _self.tagIds : tagIds // ignore: cast_nullable_to_non_nullable
+as List<int>?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as int,snapshots: null == snapshots ? _self.snapshots : snapshots // ignore: cast_nullable_to_non_nullable
 as List<Snapshot>,
   ));
@@ -87,9 +87,12 @@ as List<Snapshot>,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$TLSConfigCopyWith<$Res> get tlsConfig {
-  
-  return $TLSConfigCopyWith<$Res>(_self.tlsConfig, (value) {
+$TLSConfigCopyWith<$Res>? get tlsConfig {
+    if (_self.tlsConfig == null) {
+    return null;
+  }
+
+  return $TLSConfigCopyWith<$Res>(_self.tlsConfig!, (value) {
     return _then(_self.copyWith(tlsConfig: value));
   });
 }/// Create a copy of Environment
@@ -183,10 +186,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String name,  int type,  String containerEngine,  String url,  int groupId,  String publicUrl,  List<String> gpus,  TLSConfig tlsConfig,  AzureCredentials azureCredentials,  List<int> tagIds,  int status,  List<Snapshot> snapshots)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String name,  int type,  String? containerEngine,  String uRL,  int groupId,  String? publicUrl,  List<String>? gpus,  TLSConfig? tlsConfig,  AzureCredentials azureCredentials,  List<int>? tagIds,  int status,  List<Snapshot> snapshots)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Environment() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.containerEngine,_that.url,_that.groupId,_that.publicUrl,_that.gpus,_that.tlsConfig,_that.azureCredentials,_that.tagIds,_that.status,_that.snapshots);case _:
+return $default(_that.id,_that.name,_that.type,_that.containerEngine,_that.uRL,_that.groupId,_that.publicUrl,_that.gpus,_that.tlsConfig,_that.azureCredentials,_that.tagIds,_that.status,_that.snapshots);case _:
   return orElse();
 
 }
@@ -204,10 +207,10 @@ return $default(_that.id,_that.name,_that.type,_that.containerEngine,_that.url,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String name,  int type,  String containerEngine,  String url,  int groupId,  String publicUrl,  List<String> gpus,  TLSConfig tlsConfig,  AzureCredentials azureCredentials,  List<int> tagIds,  int status,  List<Snapshot> snapshots)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String name,  int type,  String? containerEngine,  String uRL,  int groupId,  String? publicUrl,  List<String>? gpus,  TLSConfig? tlsConfig,  AzureCredentials azureCredentials,  List<int>? tagIds,  int status,  List<Snapshot> snapshots)  $default,) {final _that = this;
 switch (_that) {
 case _Environment():
-return $default(_that.id,_that.name,_that.type,_that.containerEngine,_that.url,_that.groupId,_that.publicUrl,_that.gpus,_that.tlsConfig,_that.azureCredentials,_that.tagIds,_that.status,_that.snapshots);case _:
+return $default(_that.id,_that.name,_that.type,_that.containerEngine,_that.uRL,_that.groupId,_that.publicUrl,_that.gpus,_that.tlsConfig,_that.azureCredentials,_that.tagIds,_that.status,_that.snapshots);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -224,10 +227,10 @@ return $default(_that.id,_that.name,_that.type,_that.containerEngine,_that.url,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String name,  int type,  String containerEngine,  String url,  int groupId,  String publicUrl,  List<String> gpus,  TLSConfig tlsConfig,  AzureCredentials azureCredentials,  List<int> tagIds,  int status,  List<Snapshot> snapshots)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String name,  int type,  String? containerEngine,  String uRL,  int groupId,  String? publicUrl,  List<String>? gpus,  TLSConfig? tlsConfig,  AzureCredentials azureCredentials,  List<int>? tagIds,  int status,  List<Snapshot> snapshots)?  $default,) {final _that = this;
 switch (_that) {
 case _Environment() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.containerEngine,_that.url,_that.groupId,_that.publicUrl,_that.gpus,_that.tlsConfig,_that.azureCredentials,_that.tagIds,_that.status,_that.snapshots);case _:
+return $default(_that.id,_that.name,_that.type,_that.containerEngine,_that.uRL,_that.groupId,_that.publicUrl,_that.gpus,_that.tlsConfig,_that.azureCredentials,_that.tagIds,_that.status,_that.snapshots);case _:
   return null;
 
 }
@@ -236,33 +239,37 @@ return $default(_that.id,_that.name,_that.type,_that.containerEngine,_that.url,_
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _Environment implements Environment {
-  const _Environment({required this.id, required this.name, required this.type, required this.containerEngine, required this.url, required this.groupId, required this.publicUrl, required final  List<String> gpus, required this.tlsConfig, required this.azureCredentials, required final  List<int> tagIds, required this.status, required final  List<Snapshot> snapshots}): _gpus = gpus,_tagIds = tagIds,_snapshots = snapshots;
+  const _Environment({required this.id, required this.name, required this.type, this.containerEngine, required this.uRL, required this.groupId, this.publicUrl, final  List<String>? gpus, this.tlsConfig, required this.azureCredentials, final  List<int>? tagIds, required this.status, required final  List<Snapshot> snapshots}): _gpus = gpus,_tagIds = tagIds,_snapshots = snapshots;
   factory _Environment.fromJson(Map<String, dynamic> json) => _$EnvironmentFromJson(json);
 
 @override final  int id;
 @override final  String name;
 @override final  int type;
-@override final  String containerEngine;
-@override final  String url;
+@override final  String? containerEngine;
+@override final  String uRL;
 @override final  int groupId;
-@override final  String publicUrl;
- final  List<String> _gpus;
-@override List<String> get gpus {
+@override final  String? publicUrl;
+ final  List<String>? _gpus;
+@override List<String>? get gpus {
+  final value = _gpus;
+  if (value == null) return null;
   if (_gpus is EqualUnmodifiableListView) return _gpus;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_gpus);
+  return EqualUnmodifiableListView(value);
 }
 
-@override final  TLSConfig tlsConfig;
+@override final  TLSConfig? tlsConfig;
 @override final  AzureCredentials azureCredentials;
- final  List<int> _tagIds;
-@override List<int> get tagIds {
+ final  List<int>? _tagIds;
+@override List<int>? get tagIds {
+  final value = _tagIds;
+  if (value == null) return null;
   if (_tagIds is EqualUnmodifiableListView) return _tagIds;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_tagIds);
+  return EqualUnmodifiableListView(value);
 }
 
 @override final  int status;
@@ -287,16 +294,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Environment&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.containerEngine, containerEngine) || other.containerEngine == containerEngine)&&(identical(other.url, url) || other.url == url)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.publicUrl, publicUrl) || other.publicUrl == publicUrl)&&const DeepCollectionEquality().equals(other._gpus, _gpus)&&(identical(other.tlsConfig, tlsConfig) || other.tlsConfig == tlsConfig)&&(identical(other.azureCredentials, azureCredentials) || other.azureCredentials == azureCredentials)&&const DeepCollectionEquality().equals(other._tagIds, _tagIds)&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other._snapshots, _snapshots));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Environment&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.containerEngine, containerEngine) || other.containerEngine == containerEngine)&&(identical(other.uRL, uRL) || other.uRL == uRL)&&(identical(other.groupId, groupId) || other.groupId == groupId)&&(identical(other.publicUrl, publicUrl) || other.publicUrl == publicUrl)&&const DeepCollectionEquality().equals(other._gpus, _gpus)&&(identical(other.tlsConfig, tlsConfig) || other.tlsConfig == tlsConfig)&&(identical(other.azureCredentials, azureCredentials) || other.azureCredentials == azureCredentials)&&const DeepCollectionEquality().equals(other._tagIds, _tagIds)&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other._snapshots, _snapshots));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,type,containerEngine,url,groupId,publicUrl,const DeepCollectionEquality().hash(_gpus),tlsConfig,azureCredentials,const DeepCollectionEquality().hash(_tagIds),status,const DeepCollectionEquality().hash(_snapshots));
+int get hashCode => Object.hash(runtimeType,id,name,type,containerEngine,uRL,groupId,publicUrl,const DeepCollectionEquality().hash(_gpus),tlsConfig,azureCredentials,const DeepCollectionEquality().hash(_tagIds),status,const DeepCollectionEquality().hash(_snapshots));
 
 @override
 String toString() {
-  return 'Environment(id: $id, name: $name, type: $type, containerEngine: $containerEngine, url: $url, groupId: $groupId, publicUrl: $publicUrl, gpus: $gpus, tlsConfig: $tlsConfig, azureCredentials: $azureCredentials, tagIds: $tagIds, status: $status, snapshots: $snapshots)';
+  return 'Environment(id: $id, name: $name, type: $type, containerEngine: $containerEngine, uRL: $uRL, groupId: $groupId, publicUrl: $publicUrl, gpus: $gpus, tlsConfig: $tlsConfig, azureCredentials: $azureCredentials, tagIds: $tagIds, status: $status, snapshots: $snapshots)';
 }
 
 
@@ -307,11 +314,11 @@ abstract mixin class _$EnvironmentCopyWith<$Res> implements $EnvironmentCopyWith
   factory _$EnvironmentCopyWith(_Environment value, $Res Function(_Environment) _then) = __$EnvironmentCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String name, int type, String containerEngine, String url, int groupId, String publicUrl, List<String> gpus, TLSConfig tlsConfig, AzureCredentials azureCredentials, List<int> tagIds, int status, List<Snapshot> snapshots
+ int id, String name, int type, String? containerEngine, String uRL, int groupId, String? publicUrl, List<String>? gpus, TLSConfig? tlsConfig, AzureCredentials azureCredentials, List<int>? tagIds, int status, List<Snapshot> snapshots
 });
 
 
-@override $TLSConfigCopyWith<$Res> get tlsConfig;@override $AzureCredentialsCopyWith<$Res> get azureCredentials;
+@override $TLSConfigCopyWith<$Res>? get tlsConfig;@override $AzureCredentialsCopyWith<$Res> get azureCredentials;
 
 }
 /// @nodoc
@@ -324,20 +331,20 @@ class __$EnvironmentCopyWithImpl<$Res>
 
 /// Create a copy of Environment
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? containerEngine = null,Object? url = null,Object? groupId = null,Object? publicUrl = null,Object? gpus = null,Object? tlsConfig = null,Object? azureCredentials = null,Object? tagIds = null,Object? status = null,Object? snapshots = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? containerEngine = freezed,Object? uRL = null,Object? groupId = null,Object? publicUrl = freezed,Object? gpus = freezed,Object? tlsConfig = freezed,Object? azureCredentials = null,Object? tagIds = freezed,Object? status = null,Object? snapshots = null,}) {
   return _then(_Environment(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
-as int,containerEngine: null == containerEngine ? _self.containerEngine : containerEngine // ignore: cast_nullable_to_non_nullable
-as String,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as int,containerEngine: freezed == containerEngine ? _self.containerEngine : containerEngine // ignore: cast_nullable_to_non_nullable
+as String?,uRL: null == uRL ? _self.uRL : uRL // ignore: cast_nullable_to_non_nullable
 as String,groupId: null == groupId ? _self.groupId : groupId // ignore: cast_nullable_to_non_nullable
-as int,publicUrl: null == publicUrl ? _self.publicUrl : publicUrl // ignore: cast_nullable_to_non_nullable
-as String,gpus: null == gpus ? _self._gpus : gpus // ignore: cast_nullable_to_non_nullable
-as List<String>,tlsConfig: null == tlsConfig ? _self.tlsConfig : tlsConfig // ignore: cast_nullable_to_non_nullable
-as TLSConfig,azureCredentials: null == azureCredentials ? _self.azureCredentials : azureCredentials // ignore: cast_nullable_to_non_nullable
-as AzureCredentials,tagIds: null == tagIds ? _self._tagIds : tagIds // ignore: cast_nullable_to_non_nullable
-as List<int>,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as int,publicUrl: freezed == publicUrl ? _self.publicUrl : publicUrl // ignore: cast_nullable_to_non_nullable
+as String?,gpus: freezed == gpus ? _self._gpus : gpus // ignore: cast_nullable_to_non_nullable
+as List<String>?,tlsConfig: freezed == tlsConfig ? _self.tlsConfig : tlsConfig // ignore: cast_nullable_to_non_nullable
+as TLSConfig?,azureCredentials: null == azureCredentials ? _self.azureCredentials : azureCredentials // ignore: cast_nullable_to_non_nullable
+as AzureCredentials,tagIds: freezed == tagIds ? _self._tagIds : tagIds // ignore: cast_nullable_to_non_nullable
+as List<int>?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as int,snapshots: null == snapshots ? _self._snapshots : snapshots // ignore: cast_nullable_to_non_nullable
 as List<Snapshot>,
   ));
@@ -347,9 +354,12 @@ as List<Snapshot>,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$TLSConfigCopyWith<$Res> get tlsConfig {
-  
-  return $TLSConfigCopyWith<$Res>(_self.tlsConfig, (value) {
+$TLSConfigCopyWith<$Res>? get tlsConfig {
+    if (_self.tlsConfig == null) {
+    return null;
+  }
+
+  return $TLSConfigCopyWith<$Res>(_self.tlsConfig!, (value) {
     return _then(_self.copyWith(tlsConfig: value));
   });
 }/// Create a copy of Environment
@@ -560,8 +570,8 @@ return $default(_that.tls,_that.tlsSkipVerify);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _TLSConfig implements TLSConfig {
   const _TLSConfig({required this.tls, required this.tlsSkipVerify});
   factory _TLSConfig.fromJson(Map<String, dynamic> json) => _$TLSConfigFromJson(json);
@@ -634,7 +644,7 @@ as bool,
 /// @nodoc
 mixin _$AzureCredentials {
 
- String get applicationId; String get tenantId; String get authenticationKey;
+ String? get applicationID; String? get tenantID; String? get authenticationKey;
 /// Create a copy of AzureCredentials
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -647,16 +657,16 @@ $AzureCredentialsCopyWith<AzureCredentials> get copyWith => _$AzureCredentialsCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AzureCredentials&&(identical(other.applicationId, applicationId) || other.applicationId == applicationId)&&(identical(other.tenantId, tenantId) || other.tenantId == tenantId)&&(identical(other.authenticationKey, authenticationKey) || other.authenticationKey == authenticationKey));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AzureCredentials&&(identical(other.applicationID, applicationID) || other.applicationID == applicationID)&&(identical(other.tenantID, tenantID) || other.tenantID == tenantID)&&(identical(other.authenticationKey, authenticationKey) || other.authenticationKey == authenticationKey));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,applicationId,tenantId,authenticationKey);
+int get hashCode => Object.hash(runtimeType,applicationID,tenantID,authenticationKey);
 
 @override
 String toString() {
-  return 'AzureCredentials(applicationId: $applicationId, tenantId: $tenantId, authenticationKey: $authenticationKey)';
+  return 'AzureCredentials(applicationID: $applicationID, tenantID: $tenantID, authenticationKey: $authenticationKey)';
 }
 
 
@@ -667,7 +677,7 @@ abstract mixin class $AzureCredentialsCopyWith<$Res>  {
   factory $AzureCredentialsCopyWith(AzureCredentials value, $Res Function(AzureCredentials) _then) = _$AzureCredentialsCopyWithImpl;
 @useResult
 $Res call({
- String applicationId, String tenantId, String authenticationKey
+ String? applicationID, String? tenantID, String? authenticationKey
 });
 
 
@@ -684,12 +694,12 @@ class _$AzureCredentialsCopyWithImpl<$Res>
 
 /// Create a copy of AzureCredentials
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? applicationId = null,Object? tenantId = null,Object? authenticationKey = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? applicationID = freezed,Object? tenantID = freezed,Object? authenticationKey = freezed,}) {
   return _then(_self.copyWith(
-applicationId: null == applicationId ? _self.applicationId : applicationId // ignore: cast_nullable_to_non_nullable
-as String,tenantId: null == tenantId ? _self.tenantId : tenantId // ignore: cast_nullable_to_non_nullable
-as String,authenticationKey: null == authenticationKey ? _self.authenticationKey : authenticationKey // ignore: cast_nullable_to_non_nullable
-as String,
+applicationID: freezed == applicationID ? _self.applicationID : applicationID // ignore: cast_nullable_to_non_nullable
+as String?,tenantID: freezed == tenantID ? _self.tenantID : tenantID // ignore: cast_nullable_to_non_nullable
+as String?,authenticationKey: freezed == authenticationKey ? _self.authenticationKey : authenticationKey // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 
@@ -774,10 +784,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String applicationId,  String tenantId,  String authenticationKey)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? applicationID,  String? tenantID,  String? authenticationKey)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _AzureCredentials() when $default != null:
-return $default(_that.applicationId,_that.tenantId,_that.authenticationKey);case _:
+return $default(_that.applicationID,_that.tenantID,_that.authenticationKey);case _:
   return orElse();
 
 }
@@ -795,10 +805,10 @@ return $default(_that.applicationId,_that.tenantId,_that.authenticationKey);case
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String applicationId,  String tenantId,  String authenticationKey)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? applicationID,  String? tenantID,  String? authenticationKey)  $default,) {final _that = this;
 switch (_that) {
 case _AzureCredentials():
-return $default(_that.applicationId,_that.tenantId,_that.authenticationKey);case _:
+return $default(_that.applicationID,_that.tenantID,_that.authenticationKey);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -815,10 +825,10 @@ return $default(_that.applicationId,_that.tenantId,_that.authenticationKey);case
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String applicationId,  String tenantId,  String authenticationKey)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? applicationID,  String? tenantID,  String? authenticationKey)?  $default,) {final _that = this;
 switch (_that) {
 case _AzureCredentials() when $default != null:
-return $default(_that.applicationId,_that.tenantId,_that.authenticationKey);case _:
+return $default(_that.applicationID,_that.tenantID,_that.authenticationKey);case _:
   return null;
 
 }
@@ -827,15 +837,15 @@ return $default(_that.applicationId,_that.tenantId,_that.authenticationKey);case
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _AzureCredentials implements AzureCredentials {
-  const _AzureCredentials({required this.applicationId, required this.tenantId, required this.authenticationKey});
+  const _AzureCredentials({this.applicationID, this.tenantID, this.authenticationKey});
   factory _AzureCredentials.fromJson(Map<String, dynamic> json) => _$AzureCredentialsFromJson(json);
 
-@override final  String applicationId;
-@override final  String tenantId;
-@override final  String authenticationKey;
+@override final  String? applicationID;
+@override final  String? tenantID;
+@override final  String? authenticationKey;
 
 /// Create a copy of AzureCredentials
 /// with the given fields replaced by the non-null parameter values.
@@ -850,16 +860,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AzureCredentials&&(identical(other.applicationId, applicationId) || other.applicationId == applicationId)&&(identical(other.tenantId, tenantId) || other.tenantId == tenantId)&&(identical(other.authenticationKey, authenticationKey) || other.authenticationKey == authenticationKey));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AzureCredentials&&(identical(other.applicationID, applicationID) || other.applicationID == applicationID)&&(identical(other.tenantID, tenantID) || other.tenantID == tenantID)&&(identical(other.authenticationKey, authenticationKey) || other.authenticationKey == authenticationKey));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,applicationId,tenantId,authenticationKey);
+int get hashCode => Object.hash(runtimeType,applicationID,tenantID,authenticationKey);
 
 @override
 String toString() {
-  return 'AzureCredentials(applicationId: $applicationId, tenantId: $tenantId, authenticationKey: $authenticationKey)';
+  return 'AzureCredentials(applicationID: $applicationID, tenantID: $tenantID, authenticationKey: $authenticationKey)';
 }
 
 
@@ -870,7 +880,7 @@ abstract mixin class _$AzureCredentialsCopyWith<$Res> implements $AzureCredentia
   factory _$AzureCredentialsCopyWith(_AzureCredentials value, $Res Function(_AzureCredentials) _then) = __$AzureCredentialsCopyWithImpl;
 @override @useResult
 $Res call({
- String applicationId, String tenantId, String authenticationKey
+ String? applicationID, String? tenantID, String? authenticationKey
 });
 
 
@@ -887,12 +897,12 @@ class __$AzureCredentialsCopyWithImpl<$Res>
 
 /// Create a copy of AzureCredentials
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? applicationId = null,Object? tenantId = null,Object? authenticationKey = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? applicationID = freezed,Object? tenantID = freezed,Object? authenticationKey = freezed,}) {
   return _then(_AzureCredentials(
-applicationId: null == applicationId ? _self.applicationId : applicationId // ignore: cast_nullable_to_non_nullable
-as String,tenantId: null == tenantId ? _self.tenantId : tenantId // ignore: cast_nullable_to_non_nullable
-as String,authenticationKey: null == authenticationKey ? _self.authenticationKey : authenticationKey // ignore: cast_nullable_to_non_nullable
-as String,
+applicationID: freezed == applicationID ? _self.applicationID : applicationID // ignore: cast_nullable_to_non_nullable
+as String?,tenantID: freezed == tenantID ? _self.tenantID : tenantID // ignore: cast_nullable_to_non_nullable
+as String?,authenticationKey: freezed == authenticationKey ? _self.authenticationKey : authenticationKey // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 
@@ -903,7 +913,7 @@ as String,
 /// @nodoc
 mixin _$Snapshot {
 
- int get time; String get dockerVersion; bool get swarm; int get totalCpu; int get totalMemory; int get containerCount; int get runningContainerCount; int get stoppedContainerCount; int get healthyContainerCount; int get unhealthyContainerCount; int get volumeCount; int get imageCount; int get serviceCount; int get stackCount; DockerSnapshotRaw get dockerSnapshotRaw;
+ int get time; String get dockerVersion; bool get swarm; int get totalCPU; int get totalMemory; int get containerCount; int get runningContainerCount; int get stoppedContainerCount; int get healthyContainerCount; int get unhealthyContainerCount; int get volumeCount; int get imageCount; int get serviceCount; int get stackCount; DockerSnapshotRaw get dockerSnapshotRaw;
 /// Create a copy of Snapshot
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -916,16 +926,16 @@ $SnapshotCopyWith<Snapshot> get copyWith => _$SnapshotCopyWithImpl<Snapshot>(thi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Snapshot&&(identical(other.time, time) || other.time == time)&&(identical(other.dockerVersion, dockerVersion) || other.dockerVersion == dockerVersion)&&(identical(other.swarm, swarm) || other.swarm == swarm)&&(identical(other.totalCpu, totalCpu) || other.totalCpu == totalCpu)&&(identical(other.totalMemory, totalMemory) || other.totalMemory == totalMemory)&&(identical(other.containerCount, containerCount) || other.containerCount == containerCount)&&(identical(other.runningContainerCount, runningContainerCount) || other.runningContainerCount == runningContainerCount)&&(identical(other.stoppedContainerCount, stoppedContainerCount) || other.stoppedContainerCount == stoppedContainerCount)&&(identical(other.healthyContainerCount, healthyContainerCount) || other.healthyContainerCount == healthyContainerCount)&&(identical(other.unhealthyContainerCount, unhealthyContainerCount) || other.unhealthyContainerCount == unhealthyContainerCount)&&(identical(other.volumeCount, volumeCount) || other.volumeCount == volumeCount)&&(identical(other.imageCount, imageCount) || other.imageCount == imageCount)&&(identical(other.serviceCount, serviceCount) || other.serviceCount == serviceCount)&&(identical(other.stackCount, stackCount) || other.stackCount == stackCount)&&(identical(other.dockerSnapshotRaw, dockerSnapshotRaw) || other.dockerSnapshotRaw == dockerSnapshotRaw));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Snapshot&&(identical(other.time, time) || other.time == time)&&(identical(other.dockerVersion, dockerVersion) || other.dockerVersion == dockerVersion)&&(identical(other.swarm, swarm) || other.swarm == swarm)&&(identical(other.totalCPU, totalCPU) || other.totalCPU == totalCPU)&&(identical(other.totalMemory, totalMemory) || other.totalMemory == totalMemory)&&(identical(other.containerCount, containerCount) || other.containerCount == containerCount)&&(identical(other.runningContainerCount, runningContainerCount) || other.runningContainerCount == runningContainerCount)&&(identical(other.stoppedContainerCount, stoppedContainerCount) || other.stoppedContainerCount == stoppedContainerCount)&&(identical(other.healthyContainerCount, healthyContainerCount) || other.healthyContainerCount == healthyContainerCount)&&(identical(other.unhealthyContainerCount, unhealthyContainerCount) || other.unhealthyContainerCount == unhealthyContainerCount)&&(identical(other.volumeCount, volumeCount) || other.volumeCount == volumeCount)&&(identical(other.imageCount, imageCount) || other.imageCount == imageCount)&&(identical(other.serviceCount, serviceCount) || other.serviceCount == serviceCount)&&(identical(other.stackCount, stackCount) || other.stackCount == stackCount)&&(identical(other.dockerSnapshotRaw, dockerSnapshotRaw) || other.dockerSnapshotRaw == dockerSnapshotRaw));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,time,dockerVersion,swarm,totalCpu,totalMemory,containerCount,runningContainerCount,stoppedContainerCount,healthyContainerCount,unhealthyContainerCount,volumeCount,imageCount,serviceCount,stackCount,dockerSnapshotRaw);
+int get hashCode => Object.hash(runtimeType,time,dockerVersion,swarm,totalCPU,totalMemory,containerCount,runningContainerCount,stoppedContainerCount,healthyContainerCount,unhealthyContainerCount,volumeCount,imageCount,serviceCount,stackCount,dockerSnapshotRaw);
 
 @override
 String toString() {
-  return 'Snapshot(time: $time, dockerVersion: $dockerVersion, swarm: $swarm, totalCpu: $totalCpu, totalMemory: $totalMemory, containerCount: $containerCount, runningContainerCount: $runningContainerCount, stoppedContainerCount: $stoppedContainerCount, healthyContainerCount: $healthyContainerCount, unhealthyContainerCount: $unhealthyContainerCount, volumeCount: $volumeCount, imageCount: $imageCount, serviceCount: $serviceCount, stackCount: $stackCount, dockerSnapshotRaw: $dockerSnapshotRaw)';
+  return 'Snapshot(time: $time, dockerVersion: $dockerVersion, swarm: $swarm, totalCPU: $totalCPU, totalMemory: $totalMemory, containerCount: $containerCount, runningContainerCount: $runningContainerCount, stoppedContainerCount: $stoppedContainerCount, healthyContainerCount: $healthyContainerCount, unhealthyContainerCount: $unhealthyContainerCount, volumeCount: $volumeCount, imageCount: $imageCount, serviceCount: $serviceCount, stackCount: $stackCount, dockerSnapshotRaw: $dockerSnapshotRaw)';
 }
 
 
@@ -936,7 +946,7 @@ abstract mixin class $SnapshotCopyWith<$Res>  {
   factory $SnapshotCopyWith(Snapshot value, $Res Function(Snapshot) _then) = _$SnapshotCopyWithImpl;
 @useResult
 $Res call({
- int time, String dockerVersion, bool swarm, int totalCpu, int totalMemory, int containerCount, int runningContainerCount, int stoppedContainerCount, int healthyContainerCount, int unhealthyContainerCount, int volumeCount, int imageCount, int serviceCount, int stackCount, DockerSnapshotRaw dockerSnapshotRaw
+ int time, String dockerVersion, bool swarm, int totalCPU, int totalMemory, int containerCount, int runningContainerCount, int stoppedContainerCount, int healthyContainerCount, int unhealthyContainerCount, int volumeCount, int imageCount, int serviceCount, int stackCount, DockerSnapshotRaw dockerSnapshotRaw
 });
 
 
@@ -953,12 +963,12 @@ class _$SnapshotCopyWithImpl<$Res>
 
 /// Create a copy of Snapshot
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? time = null,Object? dockerVersion = null,Object? swarm = null,Object? totalCpu = null,Object? totalMemory = null,Object? containerCount = null,Object? runningContainerCount = null,Object? stoppedContainerCount = null,Object? healthyContainerCount = null,Object? unhealthyContainerCount = null,Object? volumeCount = null,Object? imageCount = null,Object? serviceCount = null,Object? stackCount = null,Object? dockerSnapshotRaw = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? time = null,Object? dockerVersion = null,Object? swarm = null,Object? totalCPU = null,Object? totalMemory = null,Object? containerCount = null,Object? runningContainerCount = null,Object? stoppedContainerCount = null,Object? healthyContainerCount = null,Object? unhealthyContainerCount = null,Object? volumeCount = null,Object? imageCount = null,Object? serviceCount = null,Object? stackCount = null,Object? dockerSnapshotRaw = null,}) {
   return _then(_self.copyWith(
 time: null == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
 as int,dockerVersion: null == dockerVersion ? _self.dockerVersion : dockerVersion // ignore: cast_nullable_to_non_nullable
 as String,swarm: null == swarm ? _self.swarm : swarm // ignore: cast_nullable_to_non_nullable
-as bool,totalCpu: null == totalCpu ? _self.totalCpu : totalCpu // ignore: cast_nullable_to_non_nullable
+as bool,totalCPU: null == totalCPU ? _self.totalCPU : totalCPU // ignore: cast_nullable_to_non_nullable
 as int,totalMemory: null == totalMemory ? _self.totalMemory : totalMemory // ignore: cast_nullable_to_non_nullable
 as int,containerCount: null == containerCount ? _self.containerCount : containerCount // ignore: cast_nullable_to_non_nullable
 as int,runningContainerCount: null == runningContainerCount ? _self.runningContainerCount : runningContainerCount // ignore: cast_nullable_to_non_nullable
@@ -1064,10 +1074,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount,  DockerSnapshotRaw dockerSnapshotRaw)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int time,  String dockerVersion,  bool swarm,  int totalCPU,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount,  DockerSnapshotRaw dockerSnapshotRaw)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Snapshot() when $default != null:
-return $default(_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount,_that.dockerSnapshotRaw);case _:
+return $default(_that.time,_that.dockerVersion,_that.swarm,_that.totalCPU,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount,_that.dockerSnapshotRaw);case _:
   return orElse();
 
 }
@@ -1085,10 +1095,10 @@ return $default(_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount,  DockerSnapshotRaw dockerSnapshotRaw)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int time,  String dockerVersion,  bool swarm,  int totalCPU,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount,  DockerSnapshotRaw dockerSnapshotRaw)  $default,) {final _that = this;
 switch (_that) {
 case _Snapshot():
-return $default(_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount,_that.dockerSnapshotRaw);case _:
+return $default(_that.time,_that.dockerVersion,_that.swarm,_that.totalCPU,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount,_that.dockerSnapshotRaw);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -1105,10 +1115,10 @@ return $default(_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount,  DockerSnapshotRaw dockerSnapshotRaw)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int time,  String dockerVersion,  bool swarm,  int totalCPU,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount,  DockerSnapshotRaw dockerSnapshotRaw)?  $default,) {final _that = this;
 switch (_that) {
 case _Snapshot() when $default != null:
-return $default(_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount,_that.dockerSnapshotRaw);case _:
+return $default(_that.time,_that.dockerVersion,_that.swarm,_that.totalCPU,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount,_that.dockerSnapshotRaw);case _:
   return null;
 
 }
@@ -1117,16 +1127,16 @@ return $default(_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _Snapshot implements Snapshot {
-  const _Snapshot({required this.time, required this.dockerVersion, required this.swarm, required this.totalCpu, required this.totalMemory, required this.containerCount, required this.runningContainerCount, required this.stoppedContainerCount, required this.healthyContainerCount, required this.unhealthyContainerCount, required this.volumeCount, required this.imageCount, required this.serviceCount, required this.stackCount, required this.dockerSnapshotRaw});
+  const _Snapshot({required this.time, required this.dockerVersion, required this.swarm, required this.totalCPU, required this.totalMemory, required this.containerCount, required this.runningContainerCount, required this.stoppedContainerCount, required this.healthyContainerCount, required this.unhealthyContainerCount, required this.volumeCount, required this.imageCount, required this.serviceCount, required this.stackCount, required this.dockerSnapshotRaw});
   factory _Snapshot.fromJson(Map<String, dynamic> json) => _$SnapshotFromJson(json);
 
 @override final  int time;
 @override final  String dockerVersion;
 @override final  bool swarm;
-@override final  int totalCpu;
+@override final  int totalCPU;
 @override final  int totalMemory;
 @override final  int containerCount;
 @override final  int runningContainerCount;
@@ -1152,16 +1162,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Snapshot&&(identical(other.time, time) || other.time == time)&&(identical(other.dockerVersion, dockerVersion) || other.dockerVersion == dockerVersion)&&(identical(other.swarm, swarm) || other.swarm == swarm)&&(identical(other.totalCpu, totalCpu) || other.totalCpu == totalCpu)&&(identical(other.totalMemory, totalMemory) || other.totalMemory == totalMemory)&&(identical(other.containerCount, containerCount) || other.containerCount == containerCount)&&(identical(other.runningContainerCount, runningContainerCount) || other.runningContainerCount == runningContainerCount)&&(identical(other.stoppedContainerCount, stoppedContainerCount) || other.stoppedContainerCount == stoppedContainerCount)&&(identical(other.healthyContainerCount, healthyContainerCount) || other.healthyContainerCount == healthyContainerCount)&&(identical(other.unhealthyContainerCount, unhealthyContainerCount) || other.unhealthyContainerCount == unhealthyContainerCount)&&(identical(other.volumeCount, volumeCount) || other.volumeCount == volumeCount)&&(identical(other.imageCount, imageCount) || other.imageCount == imageCount)&&(identical(other.serviceCount, serviceCount) || other.serviceCount == serviceCount)&&(identical(other.stackCount, stackCount) || other.stackCount == stackCount)&&(identical(other.dockerSnapshotRaw, dockerSnapshotRaw) || other.dockerSnapshotRaw == dockerSnapshotRaw));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Snapshot&&(identical(other.time, time) || other.time == time)&&(identical(other.dockerVersion, dockerVersion) || other.dockerVersion == dockerVersion)&&(identical(other.swarm, swarm) || other.swarm == swarm)&&(identical(other.totalCPU, totalCPU) || other.totalCPU == totalCPU)&&(identical(other.totalMemory, totalMemory) || other.totalMemory == totalMemory)&&(identical(other.containerCount, containerCount) || other.containerCount == containerCount)&&(identical(other.runningContainerCount, runningContainerCount) || other.runningContainerCount == runningContainerCount)&&(identical(other.stoppedContainerCount, stoppedContainerCount) || other.stoppedContainerCount == stoppedContainerCount)&&(identical(other.healthyContainerCount, healthyContainerCount) || other.healthyContainerCount == healthyContainerCount)&&(identical(other.unhealthyContainerCount, unhealthyContainerCount) || other.unhealthyContainerCount == unhealthyContainerCount)&&(identical(other.volumeCount, volumeCount) || other.volumeCount == volumeCount)&&(identical(other.imageCount, imageCount) || other.imageCount == imageCount)&&(identical(other.serviceCount, serviceCount) || other.serviceCount == serviceCount)&&(identical(other.stackCount, stackCount) || other.stackCount == stackCount)&&(identical(other.dockerSnapshotRaw, dockerSnapshotRaw) || other.dockerSnapshotRaw == dockerSnapshotRaw));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,time,dockerVersion,swarm,totalCpu,totalMemory,containerCount,runningContainerCount,stoppedContainerCount,healthyContainerCount,unhealthyContainerCount,volumeCount,imageCount,serviceCount,stackCount,dockerSnapshotRaw);
+int get hashCode => Object.hash(runtimeType,time,dockerVersion,swarm,totalCPU,totalMemory,containerCount,runningContainerCount,stoppedContainerCount,healthyContainerCount,unhealthyContainerCount,volumeCount,imageCount,serviceCount,stackCount,dockerSnapshotRaw);
 
 @override
 String toString() {
-  return 'Snapshot(time: $time, dockerVersion: $dockerVersion, swarm: $swarm, totalCpu: $totalCpu, totalMemory: $totalMemory, containerCount: $containerCount, runningContainerCount: $runningContainerCount, stoppedContainerCount: $stoppedContainerCount, healthyContainerCount: $healthyContainerCount, unhealthyContainerCount: $unhealthyContainerCount, volumeCount: $volumeCount, imageCount: $imageCount, serviceCount: $serviceCount, stackCount: $stackCount, dockerSnapshotRaw: $dockerSnapshotRaw)';
+  return 'Snapshot(time: $time, dockerVersion: $dockerVersion, swarm: $swarm, totalCPU: $totalCPU, totalMemory: $totalMemory, containerCount: $containerCount, runningContainerCount: $runningContainerCount, stoppedContainerCount: $stoppedContainerCount, healthyContainerCount: $healthyContainerCount, unhealthyContainerCount: $unhealthyContainerCount, volumeCount: $volumeCount, imageCount: $imageCount, serviceCount: $serviceCount, stackCount: $stackCount, dockerSnapshotRaw: $dockerSnapshotRaw)';
 }
 
 
@@ -1172,7 +1182,7 @@ abstract mixin class _$SnapshotCopyWith<$Res> implements $SnapshotCopyWith<$Res>
   factory _$SnapshotCopyWith(_Snapshot value, $Res Function(_Snapshot) _then) = __$SnapshotCopyWithImpl;
 @override @useResult
 $Res call({
- int time, String dockerVersion, bool swarm, int totalCpu, int totalMemory, int containerCount, int runningContainerCount, int stoppedContainerCount, int healthyContainerCount, int unhealthyContainerCount, int volumeCount, int imageCount, int serviceCount, int stackCount, DockerSnapshotRaw dockerSnapshotRaw
+ int time, String dockerVersion, bool swarm, int totalCPU, int totalMemory, int containerCount, int runningContainerCount, int stoppedContainerCount, int healthyContainerCount, int unhealthyContainerCount, int volumeCount, int imageCount, int serviceCount, int stackCount, DockerSnapshotRaw dockerSnapshotRaw
 });
 
 
@@ -1189,12 +1199,12 @@ class __$SnapshotCopyWithImpl<$Res>
 
 /// Create a copy of Snapshot
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? time = null,Object? dockerVersion = null,Object? swarm = null,Object? totalCpu = null,Object? totalMemory = null,Object? containerCount = null,Object? runningContainerCount = null,Object? stoppedContainerCount = null,Object? healthyContainerCount = null,Object? unhealthyContainerCount = null,Object? volumeCount = null,Object? imageCount = null,Object? serviceCount = null,Object? stackCount = null,Object? dockerSnapshotRaw = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? time = null,Object? dockerVersion = null,Object? swarm = null,Object? totalCPU = null,Object? totalMemory = null,Object? containerCount = null,Object? runningContainerCount = null,Object? stoppedContainerCount = null,Object? healthyContainerCount = null,Object? unhealthyContainerCount = null,Object? volumeCount = null,Object? imageCount = null,Object? serviceCount = null,Object? stackCount = null,Object? dockerSnapshotRaw = null,}) {
   return _then(_Snapshot(
 time: null == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
 as int,dockerVersion: null == dockerVersion ? _self.dockerVersion : dockerVersion // ignore: cast_nullable_to_non_nullable
 as String,swarm: null == swarm ? _self.swarm : swarm // ignore: cast_nullable_to_non_nullable
-as bool,totalCpu: null == totalCpu ? _self.totalCpu : totalCpu // ignore: cast_nullable_to_non_nullable
+as bool,totalCPU: null == totalCPU ? _self.totalCPU : totalCPU // ignore: cast_nullable_to_non_nullable
 as int,totalMemory: null == totalMemory ? _self.totalMemory : totalMemory // ignore: cast_nullable_to_non_nullable
 as int,containerCount: null == containerCount ? _self.containerCount : containerCount // ignore: cast_nullable_to_non_nullable
 as int,runningContainerCount: null == runningContainerCount ? _self.runningContainerCount : runningContainerCount // ignore: cast_nullable_to_non_nullable
@@ -1449,8 +1459,8 @@ return $default(_that.containers,_that.volumes,_that.networks,_that.images,_that
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _DockerSnapshotRaw implements DockerSnapshotRaw {
   const _DockerSnapshotRaw({required final  List<ContainerInfo> containers, required this.volumes, required final  List<NetworkInfo> networks, required final  List<ImageInfo> images, required this.info, required this.version}): _containers = containers,_networks = networks,_images = images;
   factory _DockerSnapshotRaw.fromJson(Map<String, dynamic> json) => _$DockerSnapshotRawFromJson(json);
@@ -1576,7 +1586,7 @@ $DockerVersionInfoCopyWith<$Res> get version {
 /// @nodoc
 mixin _$ContainerInfo {
 
- String get id; List<String> get names; String get image; String get imageId; String get command; int get created; List<PortInfo> get ports; Map<String, String> get labels; String get state; String get status; HostConfigInfo get hostConfig; NetworkSettingsInfo get networkSettings; List<MountInfo> get mounts;
+ String get id; List<String> get names; String get image; String get imageID; String get command; int get created; List<PortInfo> get ports; Map<String, String> get labels; String get state; String get status; HostConfigInfo get hostConfig; NetworkSettingsInfo get networkSettings; List<MountInfo> get mounts;
 /// Create a copy of ContainerInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1589,16 +1599,16 @@ $ContainerInfoCopyWith<ContainerInfo> get copyWith => _$ContainerInfoCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ContainerInfo&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.names, names)&&(identical(other.image, image) || other.image == image)&&(identical(other.imageId, imageId) || other.imageId == imageId)&&(identical(other.command, command) || other.command == command)&&(identical(other.created, created) || other.created == created)&&const DeepCollectionEquality().equals(other.ports, ports)&&const DeepCollectionEquality().equals(other.labels, labels)&&(identical(other.state, state) || other.state == state)&&(identical(other.status, status) || other.status == status)&&(identical(other.hostConfig, hostConfig) || other.hostConfig == hostConfig)&&(identical(other.networkSettings, networkSettings) || other.networkSettings == networkSettings)&&const DeepCollectionEquality().equals(other.mounts, mounts));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ContainerInfo&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.names, names)&&(identical(other.image, image) || other.image == image)&&(identical(other.imageID, imageID) || other.imageID == imageID)&&(identical(other.command, command) || other.command == command)&&(identical(other.created, created) || other.created == created)&&const DeepCollectionEquality().equals(other.ports, ports)&&const DeepCollectionEquality().equals(other.labels, labels)&&(identical(other.state, state) || other.state == state)&&(identical(other.status, status) || other.status == status)&&(identical(other.hostConfig, hostConfig) || other.hostConfig == hostConfig)&&(identical(other.networkSettings, networkSettings) || other.networkSettings == networkSettings)&&const DeepCollectionEquality().equals(other.mounts, mounts));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(names),image,imageId,command,created,const DeepCollectionEquality().hash(ports),const DeepCollectionEquality().hash(labels),state,status,hostConfig,networkSettings,const DeepCollectionEquality().hash(mounts));
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(names),image,imageID,command,created,const DeepCollectionEquality().hash(ports),const DeepCollectionEquality().hash(labels),state,status,hostConfig,networkSettings,const DeepCollectionEquality().hash(mounts));
 
 @override
 String toString() {
-  return 'ContainerInfo(id: $id, names: $names, image: $image, imageId: $imageId, command: $command, created: $created, ports: $ports, labels: $labels, state: $state, status: $status, hostConfig: $hostConfig, networkSettings: $networkSettings, mounts: $mounts)';
+  return 'ContainerInfo(id: $id, names: $names, image: $image, imageID: $imageID, command: $command, created: $created, ports: $ports, labels: $labels, state: $state, status: $status, hostConfig: $hostConfig, networkSettings: $networkSettings, mounts: $mounts)';
 }
 
 
@@ -1609,7 +1619,7 @@ abstract mixin class $ContainerInfoCopyWith<$Res>  {
   factory $ContainerInfoCopyWith(ContainerInfo value, $Res Function(ContainerInfo) _then) = _$ContainerInfoCopyWithImpl;
 @useResult
 $Res call({
- String id, List<String> names, String image, String imageId, String command, int created, List<PortInfo> ports, Map<String, String> labels, String state, String status, HostConfigInfo hostConfig, NetworkSettingsInfo networkSettings, List<MountInfo> mounts
+ String id, List<String> names, String image, String imageID, String command, int created, List<PortInfo> ports, Map<String, String> labels, String state, String status, HostConfigInfo hostConfig, NetworkSettingsInfo networkSettings, List<MountInfo> mounts
 });
 
 
@@ -1626,12 +1636,12 @@ class _$ContainerInfoCopyWithImpl<$Res>
 
 /// Create a copy of ContainerInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? names = null,Object? image = null,Object? imageId = null,Object? command = null,Object? created = null,Object? ports = null,Object? labels = null,Object? state = null,Object? status = null,Object? hostConfig = null,Object? networkSettings = null,Object? mounts = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? names = null,Object? image = null,Object? imageID = null,Object? command = null,Object? created = null,Object? ports = null,Object? labels = null,Object? state = null,Object? status = null,Object? hostConfig = null,Object? networkSettings = null,Object? mounts = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,names: null == names ? _self.names : names // ignore: cast_nullable_to_non_nullable
 as List<String>,image: null == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
-as String,imageId: null == imageId ? _self.imageId : imageId // ignore: cast_nullable_to_non_nullable
+as String,imageID: null == imageID ? _self.imageID : imageID // ignore: cast_nullable_to_non_nullable
 as String,command: null == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
 as String,created: null == created ? _self.created : created // ignore: cast_nullable_to_non_nullable
 as int,ports: null == ports ? _self.ports : ports // ignore: cast_nullable_to_non_nullable
@@ -1744,10 +1754,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  List<String> names,  String image,  String imageId,  String command,  int created,  List<PortInfo> ports,  Map<String, String> labels,  String state,  String status,  HostConfigInfo hostConfig,  NetworkSettingsInfo networkSettings,  List<MountInfo> mounts)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  List<String> names,  String image,  String imageID,  String command,  int created,  List<PortInfo> ports,  Map<String, String> labels,  String state,  String status,  HostConfigInfo hostConfig,  NetworkSettingsInfo networkSettings,  List<MountInfo> mounts)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _ContainerInfo() when $default != null:
-return $default(_that.id,_that.names,_that.image,_that.imageId,_that.command,_that.created,_that.ports,_that.labels,_that.state,_that.status,_that.hostConfig,_that.networkSettings,_that.mounts);case _:
+return $default(_that.id,_that.names,_that.image,_that.imageID,_that.command,_that.created,_that.ports,_that.labels,_that.state,_that.status,_that.hostConfig,_that.networkSettings,_that.mounts);case _:
   return orElse();
 
 }
@@ -1765,10 +1775,10 @@ return $default(_that.id,_that.names,_that.image,_that.imageId,_that.command,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  List<String> names,  String image,  String imageId,  String command,  int created,  List<PortInfo> ports,  Map<String, String> labels,  String state,  String status,  HostConfigInfo hostConfig,  NetworkSettingsInfo networkSettings,  List<MountInfo> mounts)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  List<String> names,  String image,  String imageID,  String command,  int created,  List<PortInfo> ports,  Map<String, String> labels,  String state,  String status,  HostConfigInfo hostConfig,  NetworkSettingsInfo networkSettings,  List<MountInfo> mounts)  $default,) {final _that = this;
 switch (_that) {
 case _ContainerInfo():
-return $default(_that.id,_that.names,_that.image,_that.imageId,_that.command,_that.created,_that.ports,_that.labels,_that.state,_that.status,_that.hostConfig,_that.networkSettings,_that.mounts);case _:
+return $default(_that.id,_that.names,_that.image,_that.imageID,_that.command,_that.created,_that.ports,_that.labels,_that.state,_that.status,_that.hostConfig,_that.networkSettings,_that.mounts);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -1785,10 +1795,10 @@ return $default(_that.id,_that.names,_that.image,_that.imageId,_that.command,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  List<String> names,  String image,  String imageId,  String command,  int created,  List<PortInfo> ports,  Map<String, String> labels,  String state,  String status,  HostConfigInfo hostConfig,  NetworkSettingsInfo networkSettings,  List<MountInfo> mounts)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  List<String> names,  String image,  String imageID,  String command,  int created,  List<PortInfo> ports,  Map<String, String> labels,  String state,  String status,  HostConfigInfo hostConfig,  NetworkSettingsInfo networkSettings,  List<MountInfo> mounts)?  $default,) {final _that = this;
 switch (_that) {
 case _ContainerInfo() when $default != null:
-return $default(_that.id,_that.names,_that.image,_that.imageId,_that.command,_that.created,_that.ports,_that.labels,_that.state,_that.status,_that.hostConfig,_that.networkSettings,_that.mounts);case _:
+return $default(_that.id,_that.names,_that.image,_that.imageID,_that.command,_that.created,_that.ports,_that.labels,_that.state,_that.status,_that.hostConfig,_that.networkSettings,_that.mounts);case _:
   return null;
 
 }
@@ -1797,10 +1807,10 @@ return $default(_that.id,_that.names,_that.image,_that.imageId,_that.command,_th
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _ContainerInfo implements ContainerInfo {
-  const _ContainerInfo({required this.id, required final  List<String> names, required this.image, required this.imageId, required this.command, required this.created, required final  List<PortInfo> ports, required final  Map<String, String> labels, required this.state, required this.status, required this.hostConfig, required this.networkSettings, required final  List<MountInfo> mounts}): _names = names,_ports = ports,_labels = labels,_mounts = mounts;
+  const _ContainerInfo({required this.id, required final  List<String> names, required this.image, required this.imageID, required this.command, required this.created, required final  List<PortInfo> ports, required final  Map<String, String> labels, required this.state, required this.status, required this.hostConfig, required this.networkSettings, required final  List<MountInfo> mounts}): _names = names,_ports = ports,_labels = labels,_mounts = mounts;
   factory _ContainerInfo.fromJson(Map<String, dynamic> json) => _$ContainerInfoFromJson(json);
 
 @override final  String id;
@@ -1812,7 +1822,7 @@ class _ContainerInfo implements ContainerInfo {
 }
 
 @override final  String image;
-@override final  String imageId;
+@override final  String imageID;
 @override final  String command;
 @override final  int created;
  final  List<PortInfo> _ports;
@@ -1854,16 +1864,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ContainerInfo&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._names, _names)&&(identical(other.image, image) || other.image == image)&&(identical(other.imageId, imageId) || other.imageId == imageId)&&(identical(other.command, command) || other.command == command)&&(identical(other.created, created) || other.created == created)&&const DeepCollectionEquality().equals(other._ports, _ports)&&const DeepCollectionEquality().equals(other._labels, _labels)&&(identical(other.state, state) || other.state == state)&&(identical(other.status, status) || other.status == status)&&(identical(other.hostConfig, hostConfig) || other.hostConfig == hostConfig)&&(identical(other.networkSettings, networkSettings) || other.networkSettings == networkSettings)&&const DeepCollectionEquality().equals(other._mounts, _mounts));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ContainerInfo&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._names, _names)&&(identical(other.image, image) || other.image == image)&&(identical(other.imageID, imageID) || other.imageID == imageID)&&(identical(other.command, command) || other.command == command)&&(identical(other.created, created) || other.created == created)&&const DeepCollectionEquality().equals(other._ports, _ports)&&const DeepCollectionEquality().equals(other._labels, _labels)&&(identical(other.state, state) || other.state == state)&&(identical(other.status, status) || other.status == status)&&(identical(other.hostConfig, hostConfig) || other.hostConfig == hostConfig)&&(identical(other.networkSettings, networkSettings) || other.networkSettings == networkSettings)&&const DeepCollectionEquality().equals(other._mounts, _mounts));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_names),image,imageId,command,created,const DeepCollectionEquality().hash(_ports),const DeepCollectionEquality().hash(_labels),state,status,hostConfig,networkSettings,const DeepCollectionEquality().hash(_mounts));
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_names),image,imageID,command,created,const DeepCollectionEquality().hash(_ports),const DeepCollectionEquality().hash(_labels),state,status,hostConfig,networkSettings,const DeepCollectionEquality().hash(_mounts));
 
 @override
 String toString() {
-  return 'ContainerInfo(id: $id, names: $names, image: $image, imageId: $imageId, command: $command, created: $created, ports: $ports, labels: $labels, state: $state, status: $status, hostConfig: $hostConfig, networkSettings: $networkSettings, mounts: $mounts)';
+  return 'ContainerInfo(id: $id, names: $names, image: $image, imageID: $imageID, command: $command, created: $created, ports: $ports, labels: $labels, state: $state, status: $status, hostConfig: $hostConfig, networkSettings: $networkSettings, mounts: $mounts)';
 }
 
 
@@ -1874,7 +1884,7 @@ abstract mixin class _$ContainerInfoCopyWith<$Res> implements $ContainerInfoCopy
   factory _$ContainerInfoCopyWith(_ContainerInfo value, $Res Function(_ContainerInfo) _then) = __$ContainerInfoCopyWithImpl;
 @override @useResult
 $Res call({
- String id, List<String> names, String image, String imageId, String command, int created, List<PortInfo> ports, Map<String, String> labels, String state, String status, HostConfigInfo hostConfig, NetworkSettingsInfo networkSettings, List<MountInfo> mounts
+ String id, List<String> names, String image, String imageID, String command, int created, List<PortInfo> ports, Map<String, String> labels, String state, String status, HostConfigInfo hostConfig, NetworkSettingsInfo networkSettings, List<MountInfo> mounts
 });
 
 
@@ -1891,12 +1901,12 @@ class __$ContainerInfoCopyWithImpl<$Res>
 
 /// Create a copy of ContainerInfo
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? names = null,Object? image = null,Object? imageId = null,Object? command = null,Object? created = null,Object? ports = null,Object? labels = null,Object? state = null,Object? status = null,Object? hostConfig = null,Object? networkSettings = null,Object? mounts = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? names = null,Object? image = null,Object? imageID = null,Object? command = null,Object? created = null,Object? ports = null,Object? labels = null,Object? state = null,Object? status = null,Object? hostConfig = null,Object? networkSettings = null,Object? mounts = null,}) {
   return _then(_ContainerInfo(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,names: null == names ? _self._names : names // ignore: cast_nullable_to_non_nullable
 as List<String>,image: null == image ? _self.image : image // ignore: cast_nullable_to_non_nullable
-as String,imageId: null == imageId ? _self.imageId : imageId // ignore: cast_nullable_to_non_nullable
+as String,imageID: null == imageID ? _self.imageID : imageID // ignore: cast_nullable_to_non_nullable
 as String,command: null == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
 as String,created: null == created ? _self.created : created // ignore: cast_nullable_to_non_nullable
 as int,ports: null == ports ? _self._ports : ports // ignore: cast_nullable_to_non_nullable
@@ -2129,8 +2139,8 @@ return $default(_that.ip,_that.privatePort,_that.publicPort,_that.type);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _PortInfo implements PortInfo {
   const _PortInfo({this.ip, required this.privatePort, this.publicPort, required this.type});
   factory _PortInfo.fromJson(Map<String, dynamic> json) => _$PortInfoFromJson(json);
@@ -2398,8 +2408,8 @@ return $default(_that.networkMode);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _HostConfigInfo implements HostConfigInfo {
   const _HostConfigInfo({required this.networkMode});
   factory _HostConfigInfo.fromJson(Map<String, dynamic> json) => _$HostConfigInfoFromJson(json);
@@ -2661,8 +2671,8 @@ return $default(_that.networks);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _NetworkSettingsInfo implements NetworkSettingsInfo {
   const _NetworkSettingsInfo({required final  Map<String, NetworkDetailInfo> networks}): _networks = networks;
   factory _NetworkSettingsInfo.fromJson(Map<String, dynamic> json) => _$NetworkSettingsInfoFromJson(json);
@@ -2739,7 +2749,7 @@ as Map<String, NetworkDetailInfo>,
 /// @nodoc
 mixin _$NetworkDetailInfo {
 
- dynamic get ipamConfig; dynamic get links; dynamic get aliases; String get macAddress; dynamic get driverOpts; String get networkId; String get endpointId; String get gateway; String get ipAddress; int get ipPrefixLen; String get ipv6Gateway; String get globalIpv6Address; int get globalIpv6PrefixLen; dynamic get dnsNames;
+ dynamic get ipamConfig; dynamic get links; dynamic get aliases; String get macAddress; dynamic get driverOpts; String get networkID; String get endpointID; String get gateway; String get iPAddress; int? get iPPrefixLen; String? get iPv6Gateway; String? get globalIPv6Address; int? get globalIPv6PrefixLen; dynamic get dnsNames;
 /// Create a copy of NetworkDetailInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -2752,16 +2762,16 @@ $NetworkDetailInfoCopyWith<NetworkDetailInfo> get copyWith => _$NetworkDetailInf
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NetworkDetailInfo&&const DeepCollectionEquality().equals(other.ipamConfig, ipamConfig)&&const DeepCollectionEquality().equals(other.links, links)&&const DeepCollectionEquality().equals(other.aliases, aliases)&&(identical(other.macAddress, macAddress) || other.macAddress == macAddress)&&const DeepCollectionEquality().equals(other.driverOpts, driverOpts)&&(identical(other.networkId, networkId) || other.networkId == networkId)&&(identical(other.endpointId, endpointId) || other.endpointId == endpointId)&&(identical(other.gateway, gateway) || other.gateway == gateway)&&(identical(other.ipAddress, ipAddress) || other.ipAddress == ipAddress)&&(identical(other.ipPrefixLen, ipPrefixLen) || other.ipPrefixLen == ipPrefixLen)&&(identical(other.ipv6Gateway, ipv6Gateway) || other.ipv6Gateway == ipv6Gateway)&&(identical(other.globalIpv6Address, globalIpv6Address) || other.globalIpv6Address == globalIpv6Address)&&(identical(other.globalIpv6PrefixLen, globalIpv6PrefixLen) || other.globalIpv6PrefixLen == globalIpv6PrefixLen)&&const DeepCollectionEquality().equals(other.dnsNames, dnsNames));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NetworkDetailInfo&&const DeepCollectionEquality().equals(other.ipamConfig, ipamConfig)&&const DeepCollectionEquality().equals(other.links, links)&&const DeepCollectionEquality().equals(other.aliases, aliases)&&(identical(other.macAddress, macAddress) || other.macAddress == macAddress)&&const DeepCollectionEquality().equals(other.driverOpts, driverOpts)&&(identical(other.networkID, networkID) || other.networkID == networkID)&&(identical(other.endpointID, endpointID) || other.endpointID == endpointID)&&(identical(other.gateway, gateway) || other.gateway == gateway)&&(identical(other.iPAddress, iPAddress) || other.iPAddress == iPAddress)&&(identical(other.iPPrefixLen, iPPrefixLen) || other.iPPrefixLen == iPPrefixLen)&&(identical(other.iPv6Gateway, iPv6Gateway) || other.iPv6Gateway == iPv6Gateway)&&(identical(other.globalIPv6Address, globalIPv6Address) || other.globalIPv6Address == globalIPv6Address)&&(identical(other.globalIPv6PrefixLen, globalIPv6PrefixLen) || other.globalIPv6PrefixLen == globalIPv6PrefixLen)&&const DeepCollectionEquality().equals(other.dnsNames, dnsNames));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(ipamConfig),const DeepCollectionEquality().hash(links),const DeepCollectionEquality().hash(aliases),macAddress,const DeepCollectionEquality().hash(driverOpts),networkId,endpointId,gateway,ipAddress,ipPrefixLen,ipv6Gateway,globalIpv6Address,globalIpv6PrefixLen,const DeepCollectionEquality().hash(dnsNames));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(ipamConfig),const DeepCollectionEquality().hash(links),const DeepCollectionEquality().hash(aliases),macAddress,const DeepCollectionEquality().hash(driverOpts),networkID,endpointID,gateway,iPAddress,iPPrefixLen,iPv6Gateway,globalIPv6Address,globalIPv6PrefixLen,const DeepCollectionEquality().hash(dnsNames));
 
 @override
 String toString() {
-  return 'NetworkDetailInfo(ipamConfig: $ipamConfig, links: $links, aliases: $aliases, macAddress: $macAddress, driverOpts: $driverOpts, networkId: $networkId, endpointId: $endpointId, gateway: $gateway, ipAddress: $ipAddress, ipPrefixLen: $ipPrefixLen, ipv6Gateway: $ipv6Gateway, globalIpv6Address: $globalIpv6Address, globalIpv6PrefixLen: $globalIpv6PrefixLen, dnsNames: $dnsNames)';
+  return 'NetworkDetailInfo(ipamConfig: $ipamConfig, links: $links, aliases: $aliases, macAddress: $macAddress, driverOpts: $driverOpts, networkID: $networkID, endpointID: $endpointID, gateway: $gateway, iPAddress: $iPAddress, iPPrefixLen: $iPPrefixLen, iPv6Gateway: $iPv6Gateway, globalIPv6Address: $globalIPv6Address, globalIPv6PrefixLen: $globalIPv6PrefixLen, dnsNames: $dnsNames)';
 }
 
 
@@ -2772,7 +2782,7 @@ abstract mixin class $NetworkDetailInfoCopyWith<$Res>  {
   factory $NetworkDetailInfoCopyWith(NetworkDetailInfo value, $Res Function(NetworkDetailInfo) _then) = _$NetworkDetailInfoCopyWithImpl;
 @useResult
 $Res call({
- dynamic ipamConfig, dynamic links, dynamic aliases, String macAddress, dynamic driverOpts, String networkId, String endpointId, String gateway, String ipAddress, int ipPrefixLen, String ipv6Gateway, String globalIpv6Address, int globalIpv6PrefixLen, dynamic dnsNames
+ dynamic ipamConfig, dynamic links, dynamic aliases, String macAddress, dynamic driverOpts, String networkID, String endpointID, String gateway, String iPAddress, int? iPPrefixLen, String? iPv6Gateway, String? globalIPv6Address, int? globalIPv6PrefixLen, dynamic dnsNames
 });
 
 
@@ -2789,22 +2799,22 @@ class _$NetworkDetailInfoCopyWithImpl<$Res>
 
 /// Create a copy of NetworkDetailInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? ipamConfig = freezed,Object? links = freezed,Object? aliases = freezed,Object? macAddress = null,Object? driverOpts = freezed,Object? networkId = null,Object? endpointId = null,Object? gateway = null,Object? ipAddress = null,Object? ipPrefixLen = null,Object? ipv6Gateway = null,Object? globalIpv6Address = null,Object? globalIpv6PrefixLen = null,Object? dnsNames = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? ipamConfig = freezed,Object? links = freezed,Object? aliases = freezed,Object? macAddress = null,Object? driverOpts = freezed,Object? networkID = null,Object? endpointID = null,Object? gateway = null,Object? iPAddress = null,Object? iPPrefixLen = freezed,Object? iPv6Gateway = freezed,Object? globalIPv6Address = freezed,Object? globalIPv6PrefixLen = freezed,Object? dnsNames = freezed,}) {
   return _then(_self.copyWith(
 ipamConfig: freezed == ipamConfig ? _self.ipamConfig : ipamConfig // ignore: cast_nullable_to_non_nullable
 as dynamic,links: freezed == links ? _self.links : links // ignore: cast_nullable_to_non_nullable
 as dynamic,aliases: freezed == aliases ? _self.aliases : aliases // ignore: cast_nullable_to_non_nullable
 as dynamic,macAddress: null == macAddress ? _self.macAddress : macAddress // ignore: cast_nullable_to_non_nullable
 as String,driverOpts: freezed == driverOpts ? _self.driverOpts : driverOpts // ignore: cast_nullable_to_non_nullable
-as dynamic,networkId: null == networkId ? _self.networkId : networkId // ignore: cast_nullable_to_non_nullable
-as String,endpointId: null == endpointId ? _self.endpointId : endpointId // ignore: cast_nullable_to_non_nullable
+as dynamic,networkID: null == networkID ? _self.networkID : networkID // ignore: cast_nullable_to_non_nullable
+as String,endpointID: null == endpointID ? _self.endpointID : endpointID // ignore: cast_nullable_to_non_nullable
 as String,gateway: null == gateway ? _self.gateway : gateway // ignore: cast_nullable_to_non_nullable
-as String,ipAddress: null == ipAddress ? _self.ipAddress : ipAddress // ignore: cast_nullable_to_non_nullable
-as String,ipPrefixLen: null == ipPrefixLen ? _self.ipPrefixLen : ipPrefixLen // ignore: cast_nullable_to_non_nullable
-as int,ipv6Gateway: null == ipv6Gateway ? _self.ipv6Gateway : ipv6Gateway // ignore: cast_nullable_to_non_nullable
-as String,globalIpv6Address: null == globalIpv6Address ? _self.globalIpv6Address : globalIpv6Address // ignore: cast_nullable_to_non_nullable
-as String,globalIpv6PrefixLen: null == globalIpv6PrefixLen ? _self.globalIpv6PrefixLen : globalIpv6PrefixLen // ignore: cast_nullable_to_non_nullable
-as int,dnsNames: freezed == dnsNames ? _self.dnsNames : dnsNames // ignore: cast_nullable_to_non_nullable
+as String,iPAddress: null == iPAddress ? _self.iPAddress : iPAddress // ignore: cast_nullable_to_non_nullable
+as String,iPPrefixLen: freezed == iPPrefixLen ? _self.iPPrefixLen : iPPrefixLen // ignore: cast_nullable_to_non_nullable
+as int?,iPv6Gateway: freezed == iPv6Gateway ? _self.iPv6Gateway : iPv6Gateway // ignore: cast_nullable_to_non_nullable
+as String?,globalIPv6Address: freezed == globalIPv6Address ? _self.globalIPv6Address : globalIPv6Address // ignore: cast_nullable_to_non_nullable
+as String?,globalIPv6PrefixLen: freezed == globalIPv6PrefixLen ? _self.globalIPv6PrefixLen : globalIPv6PrefixLen // ignore: cast_nullable_to_non_nullable
+as int?,dnsNames: freezed == dnsNames ? _self.dnsNames : dnsNames // ignore: cast_nullable_to_non_nullable
 as dynamic,
   ));
 }
@@ -2890,10 +2900,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( dynamic ipamConfig,  dynamic links,  dynamic aliases,  String macAddress,  dynamic driverOpts,  String networkId,  String endpointId,  String gateway,  String ipAddress,  int ipPrefixLen,  String ipv6Gateway,  String globalIpv6Address,  int globalIpv6PrefixLen,  dynamic dnsNames)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( dynamic ipamConfig,  dynamic links,  dynamic aliases,  String macAddress,  dynamic driverOpts,  String networkID,  String endpointID,  String gateway,  String iPAddress,  int? iPPrefixLen,  String? iPv6Gateway,  String? globalIPv6Address,  int? globalIPv6PrefixLen,  dynamic dnsNames)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NetworkDetailInfo() when $default != null:
-return $default(_that.ipamConfig,_that.links,_that.aliases,_that.macAddress,_that.driverOpts,_that.networkId,_that.endpointId,_that.gateway,_that.ipAddress,_that.ipPrefixLen,_that.ipv6Gateway,_that.globalIpv6Address,_that.globalIpv6PrefixLen,_that.dnsNames);case _:
+return $default(_that.ipamConfig,_that.links,_that.aliases,_that.macAddress,_that.driverOpts,_that.networkID,_that.endpointID,_that.gateway,_that.iPAddress,_that.iPPrefixLen,_that.iPv6Gateway,_that.globalIPv6Address,_that.globalIPv6PrefixLen,_that.dnsNames);case _:
   return orElse();
 
 }
@@ -2911,10 +2921,10 @@ return $default(_that.ipamConfig,_that.links,_that.aliases,_that.macAddress,_tha
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( dynamic ipamConfig,  dynamic links,  dynamic aliases,  String macAddress,  dynamic driverOpts,  String networkId,  String endpointId,  String gateway,  String ipAddress,  int ipPrefixLen,  String ipv6Gateway,  String globalIpv6Address,  int globalIpv6PrefixLen,  dynamic dnsNames)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( dynamic ipamConfig,  dynamic links,  dynamic aliases,  String macAddress,  dynamic driverOpts,  String networkID,  String endpointID,  String gateway,  String iPAddress,  int? iPPrefixLen,  String? iPv6Gateway,  String? globalIPv6Address,  int? globalIPv6PrefixLen,  dynamic dnsNames)  $default,) {final _that = this;
 switch (_that) {
 case _NetworkDetailInfo():
-return $default(_that.ipamConfig,_that.links,_that.aliases,_that.macAddress,_that.driverOpts,_that.networkId,_that.endpointId,_that.gateway,_that.ipAddress,_that.ipPrefixLen,_that.ipv6Gateway,_that.globalIpv6Address,_that.globalIpv6PrefixLen,_that.dnsNames);case _:
+return $default(_that.ipamConfig,_that.links,_that.aliases,_that.macAddress,_that.driverOpts,_that.networkID,_that.endpointID,_that.gateway,_that.iPAddress,_that.iPPrefixLen,_that.iPv6Gateway,_that.globalIPv6Address,_that.globalIPv6PrefixLen,_that.dnsNames);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -2931,10 +2941,10 @@ return $default(_that.ipamConfig,_that.links,_that.aliases,_that.macAddress,_tha
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( dynamic ipamConfig,  dynamic links,  dynamic aliases,  String macAddress,  dynamic driverOpts,  String networkId,  String endpointId,  String gateway,  String ipAddress,  int ipPrefixLen,  String ipv6Gateway,  String globalIpv6Address,  int globalIpv6PrefixLen,  dynamic dnsNames)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( dynamic ipamConfig,  dynamic links,  dynamic aliases,  String macAddress,  dynamic driverOpts,  String networkID,  String endpointID,  String gateway,  String iPAddress,  int? iPPrefixLen,  String? iPv6Gateway,  String? globalIPv6Address,  int? globalIPv6PrefixLen,  dynamic dnsNames)?  $default,) {final _that = this;
 switch (_that) {
 case _NetworkDetailInfo() when $default != null:
-return $default(_that.ipamConfig,_that.links,_that.aliases,_that.macAddress,_that.driverOpts,_that.networkId,_that.endpointId,_that.gateway,_that.ipAddress,_that.ipPrefixLen,_that.ipv6Gateway,_that.globalIpv6Address,_that.globalIpv6PrefixLen,_that.dnsNames);case _:
+return $default(_that.ipamConfig,_that.links,_that.aliases,_that.macAddress,_that.driverOpts,_that.networkID,_that.endpointID,_that.gateway,_that.iPAddress,_that.iPPrefixLen,_that.iPv6Gateway,_that.globalIPv6Address,_that.globalIPv6PrefixLen,_that.dnsNames);case _:
   return null;
 
 }
@@ -2943,10 +2953,10 @@ return $default(_that.ipamConfig,_that.links,_that.aliases,_that.macAddress,_tha
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _NetworkDetailInfo implements NetworkDetailInfo {
-  const _NetworkDetailInfo({this.ipamConfig, this.links, this.aliases, required this.macAddress, this.driverOpts, required this.networkId, required this.endpointId, required this.gateway, required this.ipAddress, required this.ipPrefixLen, required this.ipv6Gateway, required this.globalIpv6Address, required this.globalIpv6PrefixLen, this.dnsNames});
+  const _NetworkDetailInfo({this.ipamConfig, this.links, this.aliases, required this.macAddress, this.driverOpts, required this.networkID, required this.endpointID, required this.gateway, required this.iPAddress, this.iPPrefixLen, this.iPv6Gateway, this.globalIPv6Address, this.globalIPv6PrefixLen, this.dnsNames});
   factory _NetworkDetailInfo.fromJson(Map<String, dynamic> json) => _$NetworkDetailInfoFromJson(json);
 
 @override final  dynamic ipamConfig;
@@ -2954,14 +2964,14 @@ class _NetworkDetailInfo implements NetworkDetailInfo {
 @override final  dynamic aliases;
 @override final  String macAddress;
 @override final  dynamic driverOpts;
-@override final  String networkId;
-@override final  String endpointId;
+@override final  String networkID;
+@override final  String endpointID;
 @override final  String gateway;
-@override final  String ipAddress;
-@override final  int ipPrefixLen;
-@override final  String ipv6Gateway;
-@override final  String globalIpv6Address;
-@override final  int globalIpv6PrefixLen;
+@override final  String iPAddress;
+@override final  int? iPPrefixLen;
+@override final  String? iPv6Gateway;
+@override final  String? globalIPv6Address;
+@override final  int? globalIPv6PrefixLen;
 @override final  dynamic dnsNames;
 
 /// Create a copy of NetworkDetailInfo
@@ -2977,16 +2987,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NetworkDetailInfo&&const DeepCollectionEquality().equals(other.ipamConfig, ipamConfig)&&const DeepCollectionEquality().equals(other.links, links)&&const DeepCollectionEquality().equals(other.aliases, aliases)&&(identical(other.macAddress, macAddress) || other.macAddress == macAddress)&&const DeepCollectionEquality().equals(other.driverOpts, driverOpts)&&(identical(other.networkId, networkId) || other.networkId == networkId)&&(identical(other.endpointId, endpointId) || other.endpointId == endpointId)&&(identical(other.gateway, gateway) || other.gateway == gateway)&&(identical(other.ipAddress, ipAddress) || other.ipAddress == ipAddress)&&(identical(other.ipPrefixLen, ipPrefixLen) || other.ipPrefixLen == ipPrefixLen)&&(identical(other.ipv6Gateway, ipv6Gateway) || other.ipv6Gateway == ipv6Gateway)&&(identical(other.globalIpv6Address, globalIpv6Address) || other.globalIpv6Address == globalIpv6Address)&&(identical(other.globalIpv6PrefixLen, globalIpv6PrefixLen) || other.globalIpv6PrefixLen == globalIpv6PrefixLen)&&const DeepCollectionEquality().equals(other.dnsNames, dnsNames));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NetworkDetailInfo&&const DeepCollectionEquality().equals(other.ipamConfig, ipamConfig)&&const DeepCollectionEquality().equals(other.links, links)&&const DeepCollectionEquality().equals(other.aliases, aliases)&&(identical(other.macAddress, macAddress) || other.macAddress == macAddress)&&const DeepCollectionEquality().equals(other.driverOpts, driverOpts)&&(identical(other.networkID, networkID) || other.networkID == networkID)&&(identical(other.endpointID, endpointID) || other.endpointID == endpointID)&&(identical(other.gateway, gateway) || other.gateway == gateway)&&(identical(other.iPAddress, iPAddress) || other.iPAddress == iPAddress)&&(identical(other.iPPrefixLen, iPPrefixLen) || other.iPPrefixLen == iPPrefixLen)&&(identical(other.iPv6Gateway, iPv6Gateway) || other.iPv6Gateway == iPv6Gateway)&&(identical(other.globalIPv6Address, globalIPv6Address) || other.globalIPv6Address == globalIPv6Address)&&(identical(other.globalIPv6PrefixLen, globalIPv6PrefixLen) || other.globalIPv6PrefixLen == globalIPv6PrefixLen)&&const DeepCollectionEquality().equals(other.dnsNames, dnsNames));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(ipamConfig),const DeepCollectionEquality().hash(links),const DeepCollectionEquality().hash(aliases),macAddress,const DeepCollectionEquality().hash(driverOpts),networkId,endpointId,gateway,ipAddress,ipPrefixLen,ipv6Gateway,globalIpv6Address,globalIpv6PrefixLen,const DeepCollectionEquality().hash(dnsNames));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(ipamConfig),const DeepCollectionEquality().hash(links),const DeepCollectionEquality().hash(aliases),macAddress,const DeepCollectionEquality().hash(driverOpts),networkID,endpointID,gateway,iPAddress,iPPrefixLen,iPv6Gateway,globalIPv6Address,globalIPv6PrefixLen,const DeepCollectionEquality().hash(dnsNames));
 
 @override
 String toString() {
-  return 'NetworkDetailInfo(ipamConfig: $ipamConfig, links: $links, aliases: $aliases, macAddress: $macAddress, driverOpts: $driverOpts, networkId: $networkId, endpointId: $endpointId, gateway: $gateway, ipAddress: $ipAddress, ipPrefixLen: $ipPrefixLen, ipv6Gateway: $ipv6Gateway, globalIpv6Address: $globalIpv6Address, globalIpv6PrefixLen: $globalIpv6PrefixLen, dnsNames: $dnsNames)';
+  return 'NetworkDetailInfo(ipamConfig: $ipamConfig, links: $links, aliases: $aliases, macAddress: $macAddress, driverOpts: $driverOpts, networkID: $networkID, endpointID: $endpointID, gateway: $gateway, iPAddress: $iPAddress, iPPrefixLen: $iPPrefixLen, iPv6Gateway: $iPv6Gateway, globalIPv6Address: $globalIPv6Address, globalIPv6PrefixLen: $globalIPv6PrefixLen, dnsNames: $dnsNames)';
 }
 
 
@@ -2997,7 +3007,7 @@ abstract mixin class _$NetworkDetailInfoCopyWith<$Res> implements $NetworkDetail
   factory _$NetworkDetailInfoCopyWith(_NetworkDetailInfo value, $Res Function(_NetworkDetailInfo) _then) = __$NetworkDetailInfoCopyWithImpl;
 @override @useResult
 $Res call({
- dynamic ipamConfig, dynamic links, dynamic aliases, String macAddress, dynamic driverOpts, String networkId, String endpointId, String gateway, String ipAddress, int ipPrefixLen, String ipv6Gateway, String globalIpv6Address, int globalIpv6PrefixLen, dynamic dnsNames
+ dynamic ipamConfig, dynamic links, dynamic aliases, String macAddress, dynamic driverOpts, String networkID, String endpointID, String gateway, String iPAddress, int? iPPrefixLen, String? iPv6Gateway, String? globalIPv6Address, int? globalIPv6PrefixLen, dynamic dnsNames
 });
 
 
@@ -3014,22 +3024,22 @@ class __$NetworkDetailInfoCopyWithImpl<$Res>
 
 /// Create a copy of NetworkDetailInfo
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? ipamConfig = freezed,Object? links = freezed,Object? aliases = freezed,Object? macAddress = null,Object? driverOpts = freezed,Object? networkId = null,Object? endpointId = null,Object? gateway = null,Object? ipAddress = null,Object? ipPrefixLen = null,Object? ipv6Gateway = null,Object? globalIpv6Address = null,Object? globalIpv6PrefixLen = null,Object? dnsNames = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? ipamConfig = freezed,Object? links = freezed,Object? aliases = freezed,Object? macAddress = null,Object? driverOpts = freezed,Object? networkID = null,Object? endpointID = null,Object? gateway = null,Object? iPAddress = null,Object? iPPrefixLen = freezed,Object? iPv6Gateway = freezed,Object? globalIPv6Address = freezed,Object? globalIPv6PrefixLen = freezed,Object? dnsNames = freezed,}) {
   return _then(_NetworkDetailInfo(
 ipamConfig: freezed == ipamConfig ? _self.ipamConfig : ipamConfig // ignore: cast_nullable_to_non_nullable
 as dynamic,links: freezed == links ? _self.links : links // ignore: cast_nullable_to_non_nullable
 as dynamic,aliases: freezed == aliases ? _self.aliases : aliases // ignore: cast_nullable_to_non_nullable
 as dynamic,macAddress: null == macAddress ? _self.macAddress : macAddress // ignore: cast_nullable_to_non_nullable
 as String,driverOpts: freezed == driverOpts ? _self.driverOpts : driverOpts // ignore: cast_nullable_to_non_nullable
-as dynamic,networkId: null == networkId ? _self.networkId : networkId // ignore: cast_nullable_to_non_nullable
-as String,endpointId: null == endpointId ? _self.endpointId : endpointId // ignore: cast_nullable_to_non_nullable
+as dynamic,networkID: null == networkID ? _self.networkID : networkID // ignore: cast_nullable_to_non_nullable
+as String,endpointID: null == endpointID ? _self.endpointID : endpointID // ignore: cast_nullable_to_non_nullable
 as String,gateway: null == gateway ? _self.gateway : gateway // ignore: cast_nullable_to_non_nullable
-as String,ipAddress: null == ipAddress ? _self.ipAddress : ipAddress // ignore: cast_nullable_to_non_nullable
-as String,ipPrefixLen: null == ipPrefixLen ? _self.ipPrefixLen : ipPrefixLen // ignore: cast_nullable_to_non_nullable
-as int,ipv6Gateway: null == ipv6Gateway ? _self.ipv6Gateway : ipv6Gateway // ignore: cast_nullable_to_non_nullable
-as String,globalIpv6Address: null == globalIpv6Address ? _self.globalIpv6Address : globalIpv6Address // ignore: cast_nullable_to_non_nullable
-as String,globalIpv6PrefixLen: null == globalIpv6PrefixLen ? _self.globalIpv6PrefixLen : globalIpv6PrefixLen // ignore: cast_nullable_to_non_nullable
-as int,dnsNames: freezed == dnsNames ? _self.dnsNames : dnsNames // ignore: cast_nullable_to_non_nullable
+as String,iPAddress: null == iPAddress ? _self.iPAddress : iPAddress // ignore: cast_nullable_to_non_nullable
+as String,iPPrefixLen: freezed == iPPrefixLen ? _self.iPPrefixLen : iPPrefixLen // ignore: cast_nullable_to_non_nullable
+as int?,iPv6Gateway: freezed == iPv6Gateway ? _self.iPv6Gateway : iPv6Gateway // ignore: cast_nullable_to_non_nullable
+as String?,globalIPv6Address: freezed == globalIPv6Address ? _self.globalIPv6Address : globalIPv6Address // ignore: cast_nullable_to_non_nullable
+as String?,globalIPv6PrefixLen: freezed == globalIPv6PrefixLen ? _self.globalIPv6PrefixLen : globalIPv6PrefixLen // ignore: cast_nullable_to_non_nullable
+as int?,dnsNames: freezed == dnsNames ? _self.dnsNames : dnsNames // ignore: cast_nullable_to_non_nullable
 as dynamic,
   ));
 }
@@ -3041,7 +3051,7 @@ as dynamic,
 /// @nodoc
 mixin _$MountInfo {
 
- String get type; String? get name; String get source; String get destination; String? get driver; String get mode; bool get rw; String get propagation;
+ String get type; String? get name; String get source; String get destination; String? get driver; String get mode; bool get rW; String? get propagation;
 /// Create a copy of MountInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3054,16 +3064,16 @@ $MountInfoCopyWith<MountInfo> get copyWith => _$MountInfoCopyWithImpl<MountInfo>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MountInfo&&(identical(other.type, type) || other.type == type)&&(identical(other.name, name) || other.name == name)&&(identical(other.source, source) || other.source == source)&&(identical(other.destination, destination) || other.destination == destination)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.rw, rw) || other.rw == rw)&&(identical(other.propagation, propagation) || other.propagation == propagation));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MountInfo&&(identical(other.type, type) || other.type == type)&&(identical(other.name, name) || other.name == name)&&(identical(other.source, source) || other.source == source)&&(identical(other.destination, destination) || other.destination == destination)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.rW, rW) || other.rW == rW)&&(identical(other.propagation, propagation) || other.propagation == propagation));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,type,name,source,destination,driver,mode,rw,propagation);
+int get hashCode => Object.hash(runtimeType,type,name,source,destination,driver,mode,rW,propagation);
 
 @override
 String toString() {
-  return 'MountInfo(type: $type, name: $name, source: $source, destination: $destination, driver: $driver, mode: $mode, rw: $rw, propagation: $propagation)';
+  return 'MountInfo(type: $type, name: $name, source: $source, destination: $destination, driver: $driver, mode: $mode, rW: $rW, propagation: $propagation)';
 }
 
 
@@ -3074,7 +3084,7 @@ abstract mixin class $MountInfoCopyWith<$Res>  {
   factory $MountInfoCopyWith(MountInfo value, $Res Function(MountInfo) _then) = _$MountInfoCopyWithImpl;
 @useResult
 $Res call({
- String type, String? name, String source, String destination, String? driver, String mode, bool rw, String propagation
+ String type, String? name, String source, String destination, String? driver, String mode, bool rW, String? propagation
 });
 
 
@@ -3091,7 +3101,7 @@ class _$MountInfoCopyWithImpl<$Res>
 
 /// Create a copy of MountInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? name = freezed,Object? source = null,Object? destination = null,Object? driver = freezed,Object? mode = null,Object? rw = null,Object? propagation = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? name = freezed,Object? source = null,Object? destination = null,Object? driver = freezed,Object? mode = null,Object? rW = null,Object? propagation = freezed,}) {
   return _then(_self.copyWith(
 type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -3099,9 +3109,9 @@ as String?,source: null == source ? _self.source : source // ignore: cast_nullab
 as String,destination: null == destination ? _self.destination : destination // ignore: cast_nullable_to_non_nullable
 as String,driver: freezed == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
 as String?,mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
-as String,rw: null == rw ? _self.rw : rw // ignore: cast_nullable_to_non_nullable
-as bool,propagation: null == propagation ? _self.propagation : propagation // ignore: cast_nullable_to_non_nullable
-as String,
+as String,rW: null == rW ? _self.rW : rW // ignore: cast_nullable_to_non_nullable
+as bool,propagation: freezed == propagation ? _self.propagation : propagation // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 
@@ -3186,10 +3196,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String type,  String? name,  String source,  String destination,  String? driver,  String mode,  bool rw,  String propagation)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String type,  String? name,  String source,  String destination,  String? driver,  String mode,  bool rW,  String? propagation)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _MountInfo() when $default != null:
-return $default(_that.type,_that.name,_that.source,_that.destination,_that.driver,_that.mode,_that.rw,_that.propagation);case _:
+return $default(_that.type,_that.name,_that.source,_that.destination,_that.driver,_that.mode,_that.rW,_that.propagation);case _:
   return orElse();
 
 }
@@ -3207,10 +3217,10 @@ return $default(_that.type,_that.name,_that.source,_that.destination,_that.drive
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String type,  String? name,  String source,  String destination,  String? driver,  String mode,  bool rw,  String propagation)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String type,  String? name,  String source,  String destination,  String? driver,  String mode,  bool rW,  String? propagation)  $default,) {final _that = this;
 switch (_that) {
 case _MountInfo():
-return $default(_that.type,_that.name,_that.source,_that.destination,_that.driver,_that.mode,_that.rw,_that.propagation);case _:
+return $default(_that.type,_that.name,_that.source,_that.destination,_that.driver,_that.mode,_that.rW,_that.propagation);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -3227,10 +3237,10 @@ return $default(_that.type,_that.name,_that.source,_that.destination,_that.drive
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String type,  String? name,  String source,  String destination,  String? driver,  String mode,  bool rw,  String propagation)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String type,  String? name,  String source,  String destination,  String? driver,  String mode,  bool rW,  String? propagation)?  $default,) {final _that = this;
 switch (_that) {
 case _MountInfo() when $default != null:
-return $default(_that.type,_that.name,_that.source,_that.destination,_that.driver,_that.mode,_that.rw,_that.propagation);case _:
+return $default(_that.type,_that.name,_that.source,_that.destination,_that.driver,_that.mode,_that.rW,_that.propagation);case _:
   return null;
 
 }
@@ -3239,10 +3249,10 @@ return $default(_that.type,_that.name,_that.source,_that.destination,_that.drive
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _MountInfo implements MountInfo {
-  const _MountInfo({required this.type, this.name, required this.source, required this.destination, this.driver, required this.mode, required this.rw, required this.propagation});
+  const _MountInfo({required this.type, this.name, required this.source, required this.destination, this.driver, required this.mode, required this.rW, this.propagation});
   factory _MountInfo.fromJson(Map<String, dynamic> json) => _$MountInfoFromJson(json);
 
 @override final  String type;
@@ -3251,8 +3261,8 @@ class _MountInfo implements MountInfo {
 @override final  String destination;
 @override final  String? driver;
 @override final  String mode;
-@override final  bool rw;
-@override final  String propagation;
+@override final  bool rW;
+@override final  String? propagation;
 
 /// Create a copy of MountInfo
 /// with the given fields replaced by the non-null parameter values.
@@ -3267,16 +3277,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MountInfo&&(identical(other.type, type) || other.type == type)&&(identical(other.name, name) || other.name == name)&&(identical(other.source, source) || other.source == source)&&(identical(other.destination, destination) || other.destination == destination)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.rw, rw) || other.rw == rw)&&(identical(other.propagation, propagation) || other.propagation == propagation));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MountInfo&&(identical(other.type, type) || other.type == type)&&(identical(other.name, name) || other.name == name)&&(identical(other.source, source) || other.source == source)&&(identical(other.destination, destination) || other.destination == destination)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.rW, rW) || other.rW == rW)&&(identical(other.propagation, propagation) || other.propagation == propagation));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,type,name,source,destination,driver,mode,rw,propagation);
+int get hashCode => Object.hash(runtimeType,type,name,source,destination,driver,mode,rW,propagation);
 
 @override
 String toString() {
-  return 'MountInfo(type: $type, name: $name, source: $source, destination: $destination, driver: $driver, mode: $mode, rw: $rw, propagation: $propagation)';
+  return 'MountInfo(type: $type, name: $name, source: $source, destination: $destination, driver: $driver, mode: $mode, rW: $rW, propagation: $propagation)';
 }
 
 
@@ -3287,7 +3297,7 @@ abstract mixin class _$MountInfoCopyWith<$Res> implements $MountInfoCopyWith<$Re
   factory _$MountInfoCopyWith(_MountInfo value, $Res Function(_MountInfo) _then) = __$MountInfoCopyWithImpl;
 @override @useResult
 $Res call({
- String type, String? name, String source, String destination, String? driver, String mode, bool rw, String propagation
+ String type, String? name, String source, String destination, String? driver, String mode, bool rW, String? propagation
 });
 
 
@@ -3304,7 +3314,7 @@ class __$MountInfoCopyWithImpl<$Res>
 
 /// Create a copy of MountInfo
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? type = null,Object? name = freezed,Object? source = null,Object? destination = null,Object? driver = freezed,Object? mode = null,Object? rw = null,Object? propagation = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? type = null,Object? name = freezed,Object? source = null,Object? destination = null,Object? driver = freezed,Object? mode = null,Object? rW = null,Object? propagation = freezed,}) {
   return _then(_MountInfo(
 type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -3312,9 +3322,9 @@ as String?,source: null == source ? _self.source : source // ignore: cast_nullab
 as String,destination: null == destination ? _self.destination : destination // ignore: cast_nullable_to_non_nullable
 as String,driver: freezed == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
 as String?,mode: null == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
-as String,rw: null == rw ? _self.rw : rw // ignore: cast_nullable_to_non_nullable
-as bool,propagation: null == propagation ? _self.propagation : propagation // ignore: cast_nullable_to_non_nullable
-as String,
+as String,rW: null == rW ? _self.rW : rW // ignore: cast_nullable_to_non_nullable
+as bool,propagation: freezed == propagation ? _self.propagation : propagation // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 
@@ -3517,8 +3527,8 @@ return $default(_that.volumes,_that.warnings);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _VolumeData implements VolumeData {
   const _VolumeData({required final  List<VolumeInfo> volumes, this.warnings}): _volumes = volumes;
   factory _VolumeData.fromJson(Map<String, dynamic> json) => _$VolumeDataFromJson(json);
@@ -3597,7 +3607,7 @@ as dynamic,
 /// @nodoc
 mixin _$VolumeInfo {
 
- String get createdAt; String get driver; Map<String, String>? get labels; String get mountpoint; String get name; Map<String, String>? get options; String get scope;
+ String get createdAt; String get driver; Map<String, String>? get labels; String get mountpoint; String get name; String get scope;
 /// Create a copy of VolumeInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3610,16 +3620,16 @@ $VolumeInfoCopyWith<VolumeInfo> get copyWith => _$VolumeInfoCopyWithImpl<VolumeI
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is VolumeInfo&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.driver, driver) || other.driver == driver)&&const DeepCollectionEquality().equals(other.labels, labels)&&(identical(other.mountpoint, mountpoint) || other.mountpoint == mountpoint)&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other.options, options)&&(identical(other.scope, scope) || other.scope == scope));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VolumeInfo&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.driver, driver) || other.driver == driver)&&const DeepCollectionEquality().equals(other.labels, labels)&&(identical(other.mountpoint, mountpoint) || other.mountpoint == mountpoint)&&(identical(other.name, name) || other.name == name)&&(identical(other.scope, scope) || other.scope == scope));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,createdAt,driver,const DeepCollectionEquality().hash(labels),mountpoint,name,const DeepCollectionEquality().hash(options),scope);
+int get hashCode => Object.hash(runtimeType,createdAt,driver,const DeepCollectionEquality().hash(labels),mountpoint,name,scope);
 
 @override
 String toString() {
-  return 'VolumeInfo(createdAt: $createdAt, driver: $driver, labels: $labels, mountpoint: $mountpoint, name: $name, options: $options, scope: $scope)';
+  return 'VolumeInfo(createdAt: $createdAt, driver: $driver, labels: $labels, mountpoint: $mountpoint, name: $name, scope: $scope)';
 }
 
 
@@ -3630,7 +3640,7 @@ abstract mixin class $VolumeInfoCopyWith<$Res>  {
   factory $VolumeInfoCopyWith(VolumeInfo value, $Res Function(VolumeInfo) _then) = _$VolumeInfoCopyWithImpl;
 @useResult
 $Res call({
- String createdAt, String driver, Map<String, String>? labels, String mountpoint, String name, Map<String, String>? options, String scope
+ String createdAt, String driver, Map<String, String>? labels, String mountpoint, String name, String scope
 });
 
 
@@ -3647,15 +3657,14 @@ class _$VolumeInfoCopyWithImpl<$Res>
 
 /// Create a copy of VolumeInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? createdAt = null,Object? driver = null,Object? labels = freezed,Object? mountpoint = null,Object? name = null,Object? options = freezed,Object? scope = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? createdAt = null,Object? driver = null,Object? labels = freezed,Object? mountpoint = null,Object? name = null,Object? scope = null,}) {
   return _then(_self.copyWith(
 createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as String,driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
 as String,labels: freezed == labels ? _self.labels : labels // ignore: cast_nullable_to_non_nullable
 as Map<String, String>?,mountpoint: null == mountpoint ? _self.mountpoint : mountpoint // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,options: freezed == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
-as Map<String, String>?,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
+as String,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }
@@ -3741,10 +3750,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String createdAt,  String driver,  Map<String, String>? labels,  String mountpoint,  String name,  Map<String, String>? options,  String scope)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String createdAt,  String driver,  Map<String, String>? labels,  String mountpoint,  String name,  String scope)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _VolumeInfo() when $default != null:
-return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that.name,_that.options,_that.scope);case _:
+return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that.name,_that.scope);case _:
   return orElse();
 
 }
@@ -3762,10 +3771,10 @@ return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String createdAt,  String driver,  Map<String, String>? labels,  String mountpoint,  String name,  Map<String, String>? options,  String scope)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String createdAt,  String driver,  Map<String, String>? labels,  String mountpoint,  String name,  String scope)  $default,) {final _that = this;
 switch (_that) {
 case _VolumeInfo():
-return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that.name,_that.options,_that.scope);case _:
+return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that.name,_that.scope);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -3782,10 +3791,10 @@ return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String createdAt,  String driver,  Map<String, String>? labels,  String mountpoint,  String name,  Map<String, String>? options,  String scope)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String createdAt,  String driver,  Map<String, String>? labels,  String mountpoint,  String name,  String scope)?  $default,) {final _that = this;
 switch (_that) {
 case _VolumeInfo() when $default != null:
-return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that.name,_that.options,_that.scope);case _:
+return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that.name,_that.scope);case _:
   return null;
 
 }
@@ -3794,10 +3803,10 @@ return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _VolumeInfo implements VolumeInfo {
-  const _VolumeInfo({required this.createdAt, required this.driver, final  Map<String, String>? labels, required this.mountpoint, required this.name, final  Map<String, String>? options, required this.scope}): _labels = labels,_options = options;
+  const _VolumeInfo({required this.createdAt, required this.driver, final  Map<String, String>? labels, required this.mountpoint, required this.name, required this.scope}): _labels = labels;
   factory _VolumeInfo.fromJson(Map<String, dynamic> json) => _$VolumeInfoFromJson(json);
 
 @override final  String createdAt;
@@ -3813,15 +3822,6 @@ class _VolumeInfo implements VolumeInfo {
 
 @override final  String mountpoint;
 @override final  String name;
- final  Map<String, String>? _options;
-@override Map<String, String>? get options {
-  final value = _options;
-  if (value == null) return null;
-  if (_options is EqualUnmodifiableMapView) return _options;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableMapView(value);
-}
-
 @override final  String scope;
 
 /// Create a copy of VolumeInfo
@@ -3837,16 +3837,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VolumeInfo&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.driver, driver) || other.driver == driver)&&const DeepCollectionEquality().equals(other._labels, _labels)&&(identical(other.mountpoint, mountpoint) || other.mountpoint == mountpoint)&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other._options, _options)&&(identical(other.scope, scope) || other.scope == scope));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VolumeInfo&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.driver, driver) || other.driver == driver)&&const DeepCollectionEquality().equals(other._labels, _labels)&&(identical(other.mountpoint, mountpoint) || other.mountpoint == mountpoint)&&(identical(other.name, name) || other.name == name)&&(identical(other.scope, scope) || other.scope == scope));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,createdAt,driver,const DeepCollectionEquality().hash(_labels),mountpoint,name,const DeepCollectionEquality().hash(_options),scope);
+int get hashCode => Object.hash(runtimeType,createdAt,driver,const DeepCollectionEquality().hash(_labels),mountpoint,name,scope);
 
 @override
 String toString() {
-  return 'VolumeInfo(createdAt: $createdAt, driver: $driver, labels: $labels, mountpoint: $mountpoint, name: $name, options: $options, scope: $scope)';
+  return 'VolumeInfo(createdAt: $createdAt, driver: $driver, labels: $labels, mountpoint: $mountpoint, name: $name, scope: $scope)';
 }
 
 
@@ -3857,7 +3857,7 @@ abstract mixin class _$VolumeInfoCopyWith<$Res> implements $VolumeInfoCopyWith<$
   factory _$VolumeInfoCopyWith(_VolumeInfo value, $Res Function(_VolumeInfo) _then) = __$VolumeInfoCopyWithImpl;
 @override @useResult
 $Res call({
- String createdAt, String driver, Map<String, String>? labels, String mountpoint, String name, Map<String, String>? options, String scope
+ String createdAt, String driver, Map<String, String>? labels, String mountpoint, String name, String scope
 });
 
 
@@ -3874,15 +3874,14 @@ class __$VolumeInfoCopyWithImpl<$Res>
 
 /// Create a copy of VolumeInfo
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? createdAt = null,Object? driver = null,Object? labels = freezed,Object? mountpoint = null,Object? name = null,Object? options = freezed,Object? scope = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? createdAt = null,Object? driver = null,Object? labels = freezed,Object? mountpoint = null,Object? name = null,Object? scope = null,}) {
   return _then(_VolumeInfo(
 createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as String,driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
 as String,labels: freezed == labels ? _self._labels : labels // ignore: cast_nullable_to_non_nullable
 as Map<String, String>?,mountpoint: null == mountpoint ? _self.mountpoint : mountpoint // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,options: freezed == options ? _self._options : options // ignore: cast_nullable_to_non_nullable
-as Map<String, String>?,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
+as String,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }
@@ -3894,7 +3893,7 @@ as String,
 /// @nodoc
 mixin _$NetworkInfo {
 
- String get name; String get id; String get created; String get scope; String get driver; bool get enableIpv6; IPAMInfo get ipam; bool get internal; bool get attachable; bool get ingress; ConfigFromInfo get configFrom; bool get configOnly; Map<String, dynamic> get containers; Map<String, dynamic> get options; Map<String, dynamic> get labels;
+ String get name; String get id; String get created; String get scope; String get driver; bool get enableIPv6; bool get internal; bool get attachable; bool get ingress; ConfigFromInfo get configFrom; bool get configOnly; Map<String, dynamic> get containers; Map<String, dynamic>? get options; Map<String, dynamic> get labels;
 /// Create a copy of NetworkInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3907,16 +3906,16 @@ $NetworkInfoCopyWith<NetworkInfo> get copyWith => _$NetworkInfoCopyWithImpl<Netw
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NetworkInfo&&(identical(other.name, name) || other.name == name)&&(identical(other.id, id) || other.id == id)&&(identical(other.created, created) || other.created == created)&&(identical(other.scope, scope) || other.scope == scope)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.enableIpv6, enableIpv6) || other.enableIpv6 == enableIpv6)&&(identical(other.ipam, ipam) || other.ipam == ipam)&&(identical(other.internal, internal) || other.internal == internal)&&(identical(other.attachable, attachable) || other.attachable == attachable)&&(identical(other.ingress, ingress) || other.ingress == ingress)&&(identical(other.configFrom, configFrom) || other.configFrom == configFrom)&&(identical(other.configOnly, configOnly) || other.configOnly == configOnly)&&const DeepCollectionEquality().equals(other.containers, containers)&&const DeepCollectionEquality().equals(other.options, options)&&const DeepCollectionEquality().equals(other.labels, labels));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NetworkInfo&&(identical(other.name, name) || other.name == name)&&(identical(other.id, id) || other.id == id)&&(identical(other.created, created) || other.created == created)&&(identical(other.scope, scope) || other.scope == scope)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.enableIPv6, enableIPv6) || other.enableIPv6 == enableIPv6)&&(identical(other.internal, internal) || other.internal == internal)&&(identical(other.attachable, attachable) || other.attachable == attachable)&&(identical(other.ingress, ingress) || other.ingress == ingress)&&(identical(other.configFrom, configFrom) || other.configFrom == configFrom)&&(identical(other.configOnly, configOnly) || other.configOnly == configOnly)&&const DeepCollectionEquality().equals(other.containers, containers)&&const DeepCollectionEquality().equals(other.options, options)&&const DeepCollectionEquality().equals(other.labels, labels));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name,id,created,scope,driver,enableIpv6,ipam,internal,attachable,ingress,configFrom,configOnly,const DeepCollectionEquality().hash(containers),const DeepCollectionEquality().hash(options),const DeepCollectionEquality().hash(labels));
+int get hashCode => Object.hash(runtimeType,name,id,created,scope,driver,enableIPv6,internal,attachable,ingress,configFrom,configOnly,const DeepCollectionEquality().hash(containers),const DeepCollectionEquality().hash(options),const DeepCollectionEquality().hash(labels));
 
 @override
 String toString() {
-  return 'NetworkInfo(name: $name, id: $id, created: $created, scope: $scope, driver: $driver, enableIpv6: $enableIpv6, ipam: $ipam, internal: $internal, attachable: $attachable, ingress: $ingress, configFrom: $configFrom, configOnly: $configOnly, containers: $containers, options: $options, labels: $labels)';
+  return 'NetworkInfo(name: $name, id: $id, created: $created, scope: $scope, driver: $driver, enableIPv6: $enableIPv6, internal: $internal, attachable: $attachable, ingress: $ingress, configFrom: $configFrom, configOnly: $configOnly, containers: $containers, options: $options, labels: $labels)';
 }
 
 
@@ -3927,11 +3926,11 @@ abstract mixin class $NetworkInfoCopyWith<$Res>  {
   factory $NetworkInfoCopyWith(NetworkInfo value, $Res Function(NetworkInfo) _then) = _$NetworkInfoCopyWithImpl;
 @useResult
 $Res call({
- String name, String id, String created, String scope, String driver, bool enableIpv6, IPAMInfo ipam, bool internal, bool attachable, bool ingress, ConfigFromInfo configFrom, bool configOnly, Map<String, dynamic> containers, Map<String, dynamic> options, Map<String, dynamic> labels
+ String name, String id, String created, String scope, String driver, bool enableIPv6, bool internal, bool attachable, bool ingress, ConfigFromInfo configFrom, bool configOnly, Map<String, dynamic> containers, Map<String, dynamic>? options, Map<String, dynamic> labels
 });
 
 
-$IPAMInfoCopyWith<$Res> get ipam;$ConfigFromInfoCopyWith<$Res> get configFrom;
+$ConfigFromInfoCopyWith<$Res> get configFrom;
 
 }
 /// @nodoc
@@ -3944,36 +3943,26 @@ class _$NetworkInfoCopyWithImpl<$Res>
 
 /// Create a copy of NetworkInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? id = null,Object? created = null,Object? scope = null,Object? driver = null,Object? enableIpv6 = null,Object? ipam = null,Object? internal = null,Object? attachable = null,Object? ingress = null,Object? configFrom = null,Object? configOnly = null,Object? containers = null,Object? options = null,Object? labels = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? id = null,Object? created = null,Object? scope = null,Object? driver = null,Object? enableIPv6 = null,Object? internal = null,Object? attachable = null,Object? ingress = null,Object? configFrom = null,Object? configOnly = null,Object? containers = null,Object? options = freezed,Object? labels = null,}) {
   return _then(_self.copyWith(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,created: null == created ? _self.created : created // ignore: cast_nullable_to_non_nullable
 as String,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
 as String,driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
-as String,enableIpv6: null == enableIpv6 ? _self.enableIpv6 : enableIpv6 // ignore: cast_nullable_to_non_nullable
-as bool,ipam: null == ipam ? _self.ipam : ipam // ignore: cast_nullable_to_non_nullable
-as IPAMInfo,internal: null == internal ? _self.internal : internal // ignore: cast_nullable_to_non_nullable
+as String,enableIPv6: null == enableIPv6 ? _self.enableIPv6 : enableIPv6 // ignore: cast_nullable_to_non_nullable
+as bool,internal: null == internal ? _self.internal : internal // ignore: cast_nullable_to_non_nullable
 as bool,attachable: null == attachable ? _self.attachable : attachable // ignore: cast_nullable_to_non_nullable
 as bool,ingress: null == ingress ? _self.ingress : ingress // ignore: cast_nullable_to_non_nullable
 as bool,configFrom: null == configFrom ? _self.configFrom : configFrom // ignore: cast_nullable_to_non_nullable
 as ConfigFromInfo,configOnly: null == configOnly ? _self.configOnly : configOnly // ignore: cast_nullable_to_non_nullable
 as bool,containers: null == containers ? _self.containers : containers // ignore: cast_nullable_to_non_nullable
-as Map<String, dynamic>,options: null == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
-as Map<String, dynamic>,labels: null == labels ? _self.labels : labels // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,options: freezed == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,labels: null == labels ? _self.labels : labels // ignore: cast_nullable_to_non_nullable
 as Map<String, dynamic>,
   ));
 }
 /// Create a copy of NetworkInfo
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$IPAMInfoCopyWith<$Res> get ipam {
-  
-  return $IPAMInfoCopyWith<$Res>(_self.ipam, (value) {
-    return _then(_self.copyWith(ipam: value));
-  });
-}/// Create a copy of NetworkInfo
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
@@ -4064,10 +4053,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  String id,  String created,  String scope,  String driver,  bool enableIpv6,  IPAMInfo ipam,  bool internal,  bool attachable,  bool ingress,  ConfigFromInfo configFrom,  bool configOnly,  Map<String, dynamic> containers,  Map<String, dynamic> options,  Map<String, dynamic> labels)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  String id,  String created,  String scope,  String driver,  bool enableIPv6,  bool internal,  bool attachable,  bool ingress,  ConfigFromInfo configFrom,  bool configOnly,  Map<String, dynamic> containers,  Map<String, dynamic>? options,  Map<String, dynamic> labels)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NetworkInfo() when $default != null:
-return $default(_that.name,_that.id,_that.created,_that.scope,_that.driver,_that.enableIpv6,_that.ipam,_that.internal,_that.attachable,_that.ingress,_that.configFrom,_that.configOnly,_that.containers,_that.options,_that.labels);case _:
+return $default(_that.name,_that.id,_that.created,_that.scope,_that.driver,_that.enableIPv6,_that.internal,_that.attachable,_that.ingress,_that.configFrom,_that.configOnly,_that.containers,_that.options,_that.labels);case _:
   return orElse();
 
 }
@@ -4085,10 +4074,10 @@ return $default(_that.name,_that.id,_that.created,_that.scope,_that.driver,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  String id,  String created,  String scope,  String driver,  bool enableIpv6,  IPAMInfo ipam,  bool internal,  bool attachable,  bool ingress,  ConfigFromInfo configFrom,  bool configOnly,  Map<String, dynamic> containers,  Map<String, dynamic> options,  Map<String, dynamic> labels)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  String id,  String created,  String scope,  String driver,  bool enableIPv6,  bool internal,  bool attachable,  bool ingress,  ConfigFromInfo configFrom,  bool configOnly,  Map<String, dynamic> containers,  Map<String, dynamic>? options,  Map<String, dynamic> labels)  $default,) {final _that = this;
 switch (_that) {
 case _NetworkInfo():
-return $default(_that.name,_that.id,_that.created,_that.scope,_that.driver,_that.enableIpv6,_that.ipam,_that.internal,_that.attachable,_that.ingress,_that.configFrom,_that.configOnly,_that.containers,_that.options,_that.labels);case _:
+return $default(_that.name,_that.id,_that.created,_that.scope,_that.driver,_that.enableIPv6,_that.internal,_that.attachable,_that.ingress,_that.configFrom,_that.configOnly,_that.containers,_that.options,_that.labels);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -4105,10 +4094,10 @@ return $default(_that.name,_that.id,_that.created,_that.scope,_that.driver,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  String id,  String created,  String scope,  String driver,  bool enableIpv6,  IPAMInfo ipam,  bool internal,  bool attachable,  bool ingress,  ConfigFromInfo configFrom,  bool configOnly,  Map<String, dynamic> containers,  Map<String, dynamic> options,  Map<String, dynamic> labels)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  String id,  String created,  String scope,  String driver,  bool enableIPv6,  bool internal,  bool attachable,  bool ingress,  ConfigFromInfo configFrom,  bool configOnly,  Map<String, dynamic> containers,  Map<String, dynamic>? options,  Map<String, dynamic> labels)?  $default,) {final _that = this;
 switch (_that) {
 case _NetworkInfo() when $default != null:
-return $default(_that.name,_that.id,_that.created,_that.scope,_that.driver,_that.enableIpv6,_that.ipam,_that.internal,_that.attachable,_that.ingress,_that.configFrom,_that.configOnly,_that.containers,_that.options,_that.labels);case _:
+return $default(_that.name,_that.id,_that.created,_that.scope,_that.driver,_that.enableIPv6,_that.internal,_that.attachable,_that.ingress,_that.configFrom,_that.configOnly,_that.containers,_that.options,_that.labels);case _:
   return null;
 
 }
@@ -4117,10 +4106,10 @@ return $default(_that.name,_that.id,_that.created,_that.scope,_that.driver,_that
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _NetworkInfo implements NetworkInfo {
-  const _NetworkInfo({required this.name, required this.id, required this.created, required this.scope, required this.driver, required this.enableIpv6, required this.ipam, required this.internal, required this.attachable, required this.ingress, required this.configFrom, required this.configOnly, required final  Map<String, dynamic> containers, required final  Map<String, dynamic> options, required final  Map<String, dynamic> labels}): _containers = containers,_options = options,_labels = labels;
+  const _NetworkInfo({required this.name, required this.id, required this.created, required this.scope, required this.driver, required this.enableIPv6, required this.internal, required this.attachable, required this.ingress, required this.configFrom, required this.configOnly, required final  Map<String, dynamic> containers, final  Map<String, dynamic>? options, required final  Map<String, dynamic> labels}): _containers = containers,_options = options,_labels = labels;
   factory _NetworkInfo.fromJson(Map<String, dynamic> json) => _$NetworkInfoFromJson(json);
 
 @override final  String name;
@@ -4128,8 +4117,7 @@ class _NetworkInfo implements NetworkInfo {
 @override final  String created;
 @override final  String scope;
 @override final  String driver;
-@override final  bool enableIpv6;
-@override final  IPAMInfo ipam;
+@override final  bool enableIPv6;
 @override final  bool internal;
 @override final  bool attachable;
 @override final  bool ingress;
@@ -4142,11 +4130,13 @@ class _NetworkInfo implements NetworkInfo {
   return EqualUnmodifiableMapView(_containers);
 }
 
- final  Map<String, dynamic> _options;
-@override Map<String, dynamic> get options {
+ final  Map<String, dynamic>? _options;
+@override Map<String, dynamic>? get options {
+  final value = _options;
+  if (value == null) return null;
   if (_options is EqualUnmodifiableMapView) return _options;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableMapView(_options);
+  return EqualUnmodifiableMapView(value);
 }
 
  final  Map<String, dynamic> _labels;
@@ -4170,16 +4160,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NetworkInfo&&(identical(other.name, name) || other.name == name)&&(identical(other.id, id) || other.id == id)&&(identical(other.created, created) || other.created == created)&&(identical(other.scope, scope) || other.scope == scope)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.enableIpv6, enableIpv6) || other.enableIpv6 == enableIpv6)&&(identical(other.ipam, ipam) || other.ipam == ipam)&&(identical(other.internal, internal) || other.internal == internal)&&(identical(other.attachable, attachable) || other.attachable == attachable)&&(identical(other.ingress, ingress) || other.ingress == ingress)&&(identical(other.configFrom, configFrom) || other.configFrom == configFrom)&&(identical(other.configOnly, configOnly) || other.configOnly == configOnly)&&const DeepCollectionEquality().equals(other._containers, _containers)&&const DeepCollectionEquality().equals(other._options, _options)&&const DeepCollectionEquality().equals(other._labels, _labels));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NetworkInfo&&(identical(other.name, name) || other.name == name)&&(identical(other.id, id) || other.id == id)&&(identical(other.created, created) || other.created == created)&&(identical(other.scope, scope) || other.scope == scope)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.enableIPv6, enableIPv6) || other.enableIPv6 == enableIPv6)&&(identical(other.internal, internal) || other.internal == internal)&&(identical(other.attachable, attachable) || other.attachable == attachable)&&(identical(other.ingress, ingress) || other.ingress == ingress)&&(identical(other.configFrom, configFrom) || other.configFrom == configFrom)&&(identical(other.configOnly, configOnly) || other.configOnly == configOnly)&&const DeepCollectionEquality().equals(other._containers, _containers)&&const DeepCollectionEquality().equals(other._options, _options)&&const DeepCollectionEquality().equals(other._labels, _labels));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name,id,created,scope,driver,enableIpv6,ipam,internal,attachable,ingress,configFrom,configOnly,const DeepCollectionEquality().hash(_containers),const DeepCollectionEquality().hash(_options),const DeepCollectionEquality().hash(_labels));
+int get hashCode => Object.hash(runtimeType,name,id,created,scope,driver,enableIPv6,internal,attachable,ingress,configFrom,configOnly,const DeepCollectionEquality().hash(_containers),const DeepCollectionEquality().hash(_options),const DeepCollectionEquality().hash(_labels));
 
 @override
 String toString() {
-  return 'NetworkInfo(name: $name, id: $id, created: $created, scope: $scope, driver: $driver, enableIpv6: $enableIpv6, ipam: $ipam, internal: $internal, attachable: $attachable, ingress: $ingress, configFrom: $configFrom, configOnly: $configOnly, containers: $containers, options: $options, labels: $labels)';
+  return 'NetworkInfo(name: $name, id: $id, created: $created, scope: $scope, driver: $driver, enableIPv6: $enableIPv6, internal: $internal, attachable: $attachable, ingress: $ingress, configFrom: $configFrom, configOnly: $configOnly, containers: $containers, options: $options, labels: $labels)';
 }
 
 
@@ -4190,11 +4180,11 @@ abstract mixin class _$NetworkInfoCopyWith<$Res> implements $NetworkInfoCopyWith
   factory _$NetworkInfoCopyWith(_NetworkInfo value, $Res Function(_NetworkInfo) _then) = __$NetworkInfoCopyWithImpl;
 @override @useResult
 $Res call({
- String name, String id, String created, String scope, String driver, bool enableIpv6, IPAMInfo ipam, bool internal, bool attachable, bool ingress, ConfigFromInfo configFrom, bool configOnly, Map<String, dynamic> containers, Map<String, dynamic> options, Map<String, dynamic> labels
+ String name, String id, String created, String scope, String driver, bool enableIPv6, bool internal, bool attachable, bool ingress, ConfigFromInfo configFrom, bool configOnly, Map<String, dynamic> containers, Map<String, dynamic>? options, Map<String, dynamic> labels
 });
 
 
-@override $IPAMInfoCopyWith<$Res> get ipam;@override $ConfigFromInfoCopyWith<$Res> get configFrom;
+@override $ConfigFromInfoCopyWith<$Res> get configFrom;
 
 }
 /// @nodoc
@@ -4207,37 +4197,27 @@ class __$NetworkInfoCopyWithImpl<$Res>
 
 /// Create a copy of NetworkInfo
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? id = null,Object? created = null,Object? scope = null,Object? driver = null,Object? enableIpv6 = null,Object? ipam = null,Object? internal = null,Object? attachable = null,Object? ingress = null,Object? configFrom = null,Object? configOnly = null,Object? containers = null,Object? options = null,Object? labels = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? id = null,Object? created = null,Object? scope = null,Object? driver = null,Object? enableIPv6 = null,Object? internal = null,Object? attachable = null,Object? ingress = null,Object? configFrom = null,Object? configOnly = null,Object? containers = null,Object? options = freezed,Object? labels = null,}) {
   return _then(_NetworkInfo(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,created: null == created ? _self.created : created // ignore: cast_nullable_to_non_nullable
 as String,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
 as String,driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
-as String,enableIpv6: null == enableIpv6 ? _self.enableIpv6 : enableIpv6 // ignore: cast_nullable_to_non_nullable
-as bool,ipam: null == ipam ? _self.ipam : ipam // ignore: cast_nullable_to_non_nullable
-as IPAMInfo,internal: null == internal ? _self.internal : internal // ignore: cast_nullable_to_non_nullable
+as String,enableIPv6: null == enableIPv6 ? _self.enableIPv6 : enableIPv6 // ignore: cast_nullable_to_non_nullable
+as bool,internal: null == internal ? _self.internal : internal // ignore: cast_nullable_to_non_nullable
 as bool,attachable: null == attachable ? _self.attachable : attachable // ignore: cast_nullable_to_non_nullable
 as bool,ingress: null == ingress ? _self.ingress : ingress // ignore: cast_nullable_to_non_nullable
 as bool,configFrom: null == configFrom ? _self.configFrom : configFrom // ignore: cast_nullable_to_non_nullable
 as ConfigFromInfo,configOnly: null == configOnly ? _self.configOnly : configOnly // ignore: cast_nullable_to_non_nullable
 as bool,containers: null == containers ? _self._containers : containers // ignore: cast_nullable_to_non_nullable
-as Map<String, dynamic>,options: null == options ? _self._options : options // ignore: cast_nullable_to_non_nullable
-as Map<String, dynamic>,labels: null == labels ? _self._labels : labels // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,options: freezed == options ? _self._options : options // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,labels: null == labels ? _self._labels : labels // ignore: cast_nullable_to_non_nullable
 as Map<String, dynamic>,
   ));
 }
 
 /// Create a copy of NetworkInfo
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$IPAMInfoCopyWith<$Res> get ipam {
-  
-  return $IPAMInfoCopyWith<$Res>(_self.ipam, (value) {
-    return _then(_self.copyWith(ipam: value));
-  });
-}/// Create a copy of NetworkInfo
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
@@ -4247,287 +4227,6 @@ $ConfigFromInfoCopyWith<$Res> get configFrom {
     return _then(_self.copyWith(configFrom: value));
   });
 }
-}
-
-
-/// @nodoc
-mixin _$IPAMInfo {
-
- String get driver; Map<String, dynamic> get options; List<IPAMConfigInfo> get config;
-/// Create a copy of IPAMInfo
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$IPAMInfoCopyWith<IPAMInfo> get copyWith => _$IPAMInfoCopyWithImpl<IPAMInfo>(this as IPAMInfo, _$identity);
-
-  /// Serializes this IPAMInfo to a JSON map.
-  Map<String, dynamic> toJson();
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is IPAMInfo&&(identical(other.driver, driver) || other.driver == driver)&&const DeepCollectionEquality().equals(other.options, options)&&const DeepCollectionEquality().equals(other.config, config));
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => Object.hash(runtimeType,driver,const DeepCollectionEquality().hash(options),const DeepCollectionEquality().hash(config));
-
-@override
-String toString() {
-  return 'IPAMInfo(driver: $driver, options: $options, config: $config)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class $IPAMInfoCopyWith<$Res>  {
-  factory $IPAMInfoCopyWith(IPAMInfo value, $Res Function(IPAMInfo) _then) = _$IPAMInfoCopyWithImpl;
-@useResult
-$Res call({
- String driver, Map<String, dynamic> options, List<IPAMConfigInfo> config
-});
-
-
-
-
-}
-/// @nodoc
-class _$IPAMInfoCopyWithImpl<$Res>
-    implements $IPAMInfoCopyWith<$Res> {
-  _$IPAMInfoCopyWithImpl(this._self, this._then);
-
-  final IPAMInfo _self;
-  final $Res Function(IPAMInfo) _then;
-
-/// Create a copy of IPAMInfo
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? driver = null,Object? options = null,Object? config = null,}) {
-  return _then(_self.copyWith(
-driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
-as String,options: null == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
-as Map<String, dynamic>,config: null == config ? _self.config : config // ignore: cast_nullable_to_non_nullable
-as List<IPAMConfigInfo>,
-  ));
-}
-
-}
-
-
-/// Adds pattern-matching-related methods to [IPAMInfo].
-extension IPAMInfoPatterns on IPAMInfo {
-/// A variant of `map` that fallback to returning `orElse`.
-///
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case final Subclass value:
-///     return ...;
-///   case _:
-///     return orElse();
-/// }
-/// ```
-
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _IPAMInfo value)?  $default,{required TResult orElse(),}){
-final _that = this;
-switch (_that) {
-case _IPAMInfo() when $default != null:
-return $default(_that);case _:
-  return orElse();
-
-}
-}
-/// A `switch`-like method, using callbacks.
-///
-/// Callbacks receives the raw object, upcasted.
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case final Subclass value:
-///     return ...;
-///   case final Subclass2 value:
-///     return ...;
-/// }
-/// ```
-
-@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _IPAMInfo value)  $default,){
-final _that = this;
-switch (_that) {
-case _IPAMInfo():
-return $default(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
-}
-/// A variant of `map` that fallback to returning `null`.
-///
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case final Subclass value:
-///     return ...;
-///   case _:
-///     return null;
-/// }
-/// ```
-
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _IPAMInfo value)?  $default,){
-final _that = this;
-switch (_that) {
-case _IPAMInfo() when $default != null:
-return $default(_that);case _:
-  return null;
-
-}
-}
-/// A variant of `when` that fallback to an `orElse` callback.
-///
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case Subclass(:final field):
-///     return ...;
-///   case _:
-///     return orElse();
-/// }
-/// ```
-
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String driver,  Map<String, dynamic> options,  List<IPAMConfigInfo> config)?  $default,{required TResult orElse(),}) {final _that = this;
-switch (_that) {
-case _IPAMInfo() when $default != null:
-return $default(_that.driver,_that.options,_that.config);case _:
-  return orElse();
-
-}
-}
-/// A `switch`-like method, using callbacks.
-///
-/// As opposed to `map`, this offers destructuring.
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case Subclass(:final field):
-///     return ...;
-///   case Subclass2(:final field2):
-///     return ...;
-/// }
-/// ```
-
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String driver,  Map<String, dynamic> options,  List<IPAMConfigInfo> config)  $default,) {final _that = this;
-switch (_that) {
-case _IPAMInfo():
-return $default(_that.driver,_that.options,_that.config);case _:
-  throw StateError('Unexpected subclass');
-
-}
-}
-/// A variant of `when` that fallback to returning `null`
-///
-/// It is equivalent to doing:
-/// ```dart
-/// switch (sealedClass) {
-///   case Subclass(:final field):
-///     return ...;
-///   case _:
-///     return null;
-/// }
-/// ```
-
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String driver,  Map<String, dynamic> options,  List<IPAMConfigInfo> config)?  $default,) {final _that = this;
-switch (_that) {
-case _IPAMInfo() when $default != null:
-return $default(_that.driver,_that.options,_that.config);case _:
-  return null;
-
-}
-}
-
-}
-
-/// @nodoc
-@JsonSerializable()
-
-class _IPAMInfo implements IPAMInfo {
-  const _IPAMInfo({required this.driver, required final  Map<String, dynamic> options, required final  List<IPAMConfigInfo> config}): _options = options,_config = config;
-  factory _IPAMInfo.fromJson(Map<String, dynamic> json) => _$IPAMInfoFromJson(json);
-
-@override final  String driver;
- final  Map<String, dynamic> _options;
-@override Map<String, dynamic> get options {
-  if (_options is EqualUnmodifiableMapView) return _options;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableMapView(_options);
-}
-
- final  List<IPAMConfigInfo> _config;
-@override List<IPAMConfigInfo> get config {
-  if (_config is EqualUnmodifiableListView) return _config;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_config);
-}
-
-
-/// Create a copy of IPAMInfo
-/// with the given fields replaced by the non-null parameter values.
-@override @JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-_$IPAMInfoCopyWith<_IPAMInfo> get copyWith => __$IPAMInfoCopyWithImpl<_IPAMInfo>(this, _$identity);
-
-@override
-Map<String, dynamic> toJson() {
-  return _$IPAMInfoToJson(this, );
-}
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _IPAMInfo&&(identical(other.driver, driver) || other.driver == driver)&&const DeepCollectionEquality().equals(other._options, _options)&&const DeepCollectionEquality().equals(other._config, _config));
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => Object.hash(runtimeType,driver,const DeepCollectionEquality().hash(_options),const DeepCollectionEquality().hash(_config));
-
-@override
-String toString() {
-  return 'IPAMInfo(driver: $driver, options: $options, config: $config)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class _$IPAMInfoCopyWith<$Res> implements $IPAMInfoCopyWith<$Res> {
-  factory _$IPAMInfoCopyWith(_IPAMInfo value, $Res Function(_IPAMInfo) _then) = __$IPAMInfoCopyWithImpl;
-@override @useResult
-$Res call({
- String driver, Map<String, dynamic> options, List<IPAMConfigInfo> config
-});
-
-
-
-
-}
-/// @nodoc
-class __$IPAMInfoCopyWithImpl<$Res>
-    implements _$IPAMInfoCopyWith<$Res> {
-  __$IPAMInfoCopyWithImpl(this._self, this._then);
-
-  final _IPAMInfo _self;
-  final $Res Function(_IPAMInfo) _then;
-
-/// Create a copy of IPAMInfo
-/// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? driver = null,Object? options = null,Object? config = null,}) {
-  return _then(_IPAMInfo(
-driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
-as String,options: null == options ? _self._options : options // ignore: cast_nullable_to_non_nullable
-as Map<String, dynamic>,config: null == config ? _self._config : config // ignore: cast_nullable_to_non_nullable
-as List<IPAMConfigInfo>,
-  ));
-}
-
-
 }
 
 
@@ -4726,8 +4425,8 @@ return $default(_that.subnet,_that.gateway);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _IPAMConfigInfo implements IPAMConfigInfo {
   const _IPAMConfigInfo({required this.subnet, required this.gateway});
   factory _IPAMConfigInfo.fromJson(Map<String, dynamic> json) => _$IPAMConfigInfoFromJson(json);
@@ -4991,8 +4690,8 @@ return $default(_that.network);case _:
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _ConfigFromInfo implements ConfigFromInfo {
   const _ConfigFromInfo({required this.network});
   factory _ConfigFromInfo.fromJson(Map<String, dynamic> json) => _$ConfigFromInfoFromJson(json);
@@ -5262,8 +4961,8 @@ return $default(_that.containers,_that.created,_that.id,_that.labels,_that.paren
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _ImageInfo implements ImageInfo {
   const _ImageInfo({required this.containers, required this.created, required this.id, final  Map<String, dynamic>? labels, required this.parentId, required final  List<String> repoDigests, required final  List<String> repoTags, required this.sharedSize, required this.size}): _labels = labels,_repoDigests = repoDigests,_repoTags = repoTags;
   factory _ImageInfo.fromJson(Map<String, dynamic> json) => _$ImageInfoFromJson(json);
@@ -5370,7 +5069,7 @@ as int,
 /// @nodoc
 mixin _$DockerInfo {
 
- String get id; int get containers; int get containersRunning; int get containersPaused; int get containersStopped; int get images; String get driver; int get ncpu; int get memTotal; String get name; String get serverVersion;
+@JsonKey(name: "ID") String get id; int get containers; int get containersRunning; int get containersPaused; int get containersStopped; int get images; String get driver; int get nCPU; int get memTotal; String get name; String get serverVersion;
 /// Create a copy of DockerInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -5383,16 +5082,16 @@ $DockerInfoCopyWith<DockerInfo> get copyWith => _$DockerInfoCopyWithImpl<DockerI
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is DockerInfo&&(identical(other.id, id) || other.id == id)&&(identical(other.containers, containers) || other.containers == containers)&&(identical(other.containersRunning, containersRunning) || other.containersRunning == containersRunning)&&(identical(other.containersPaused, containersPaused) || other.containersPaused == containersPaused)&&(identical(other.containersStopped, containersStopped) || other.containersStopped == containersStopped)&&(identical(other.images, images) || other.images == images)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.ncpu, ncpu) || other.ncpu == ncpu)&&(identical(other.memTotal, memTotal) || other.memTotal == memTotal)&&(identical(other.name, name) || other.name == name)&&(identical(other.serverVersion, serverVersion) || other.serverVersion == serverVersion));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DockerInfo&&(identical(other.id, id) || other.id == id)&&(identical(other.containers, containers) || other.containers == containers)&&(identical(other.containersRunning, containersRunning) || other.containersRunning == containersRunning)&&(identical(other.containersPaused, containersPaused) || other.containersPaused == containersPaused)&&(identical(other.containersStopped, containersStopped) || other.containersStopped == containersStopped)&&(identical(other.images, images) || other.images == images)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.nCPU, nCPU) || other.nCPU == nCPU)&&(identical(other.memTotal, memTotal) || other.memTotal == memTotal)&&(identical(other.name, name) || other.name == name)&&(identical(other.serverVersion, serverVersion) || other.serverVersion == serverVersion));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,containers,containersRunning,containersPaused,containersStopped,images,driver,ncpu,memTotal,name,serverVersion);
+int get hashCode => Object.hash(runtimeType,id,containers,containersRunning,containersPaused,containersStopped,images,driver,nCPU,memTotal,name,serverVersion);
 
 @override
 String toString() {
-  return 'DockerInfo(id: $id, containers: $containers, containersRunning: $containersRunning, containersPaused: $containersPaused, containersStopped: $containersStopped, images: $images, driver: $driver, ncpu: $ncpu, memTotal: $memTotal, name: $name, serverVersion: $serverVersion)';
+  return 'DockerInfo(id: $id, containers: $containers, containersRunning: $containersRunning, containersPaused: $containersPaused, containersStopped: $containersStopped, images: $images, driver: $driver, nCPU: $nCPU, memTotal: $memTotal, name: $name, serverVersion: $serverVersion)';
 }
 
 
@@ -5403,7 +5102,7 @@ abstract mixin class $DockerInfoCopyWith<$Res>  {
   factory $DockerInfoCopyWith(DockerInfo value, $Res Function(DockerInfo) _then) = _$DockerInfoCopyWithImpl;
 @useResult
 $Res call({
- String id, int containers, int containersRunning, int containersPaused, int containersStopped, int images, String driver, int ncpu, int memTotal, String name, String serverVersion
+@JsonKey(name: "ID") String id, int containers, int containersRunning, int containersPaused, int containersStopped, int images, String driver, int nCPU, int memTotal, String name, String serverVersion
 });
 
 
@@ -5420,7 +5119,7 @@ class _$DockerInfoCopyWithImpl<$Res>
 
 /// Create a copy of DockerInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? containers = null,Object? containersRunning = null,Object? containersPaused = null,Object? containersStopped = null,Object? images = null,Object? driver = null,Object? ncpu = null,Object? memTotal = null,Object? name = null,Object? serverVersion = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? containers = null,Object? containersRunning = null,Object? containersPaused = null,Object? containersStopped = null,Object? images = null,Object? driver = null,Object? nCPU = null,Object? memTotal = null,Object? name = null,Object? serverVersion = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,containers: null == containers ? _self.containers : containers // ignore: cast_nullable_to_non_nullable
@@ -5429,7 +5128,7 @@ as int,containersPaused: null == containersPaused ? _self.containersPaused : con
 as int,containersStopped: null == containersStopped ? _self.containersStopped : containersStopped // ignore: cast_nullable_to_non_nullable
 as int,images: null == images ? _self.images : images // ignore: cast_nullable_to_non_nullable
 as int,driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
-as String,ncpu: null == ncpu ? _self.ncpu : ncpu // ignore: cast_nullable_to_non_nullable
+as String,nCPU: null == nCPU ? _self.nCPU : nCPU // ignore: cast_nullable_to_non_nullable
 as int,memTotal: null == memTotal ? _self.memTotal : memTotal // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,serverVersion: null == serverVersion ? _self.serverVersion : serverVersion // ignore: cast_nullable_to_non_nullable
@@ -5518,10 +5217,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  int containers,  int containersRunning,  int containersPaused,  int containersStopped,  int images,  String driver,  int ncpu,  int memTotal,  String name,  String serverVersion)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: "ID")  String id,  int containers,  int containersRunning,  int containersPaused,  int containersStopped,  int images,  String driver,  int nCPU,  int memTotal,  String name,  String serverVersion)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _DockerInfo() when $default != null:
-return $default(_that.id,_that.containers,_that.containersRunning,_that.containersPaused,_that.containersStopped,_that.images,_that.driver,_that.ncpu,_that.memTotal,_that.name,_that.serverVersion);case _:
+return $default(_that.id,_that.containers,_that.containersRunning,_that.containersPaused,_that.containersStopped,_that.images,_that.driver,_that.nCPU,_that.memTotal,_that.name,_that.serverVersion);case _:
   return orElse();
 
 }
@@ -5539,10 +5238,10 @@ return $default(_that.id,_that.containers,_that.containersRunning,_that.containe
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  int containers,  int containersRunning,  int containersPaused,  int containersStopped,  int images,  String driver,  int ncpu,  int memTotal,  String name,  String serverVersion)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: "ID")  String id,  int containers,  int containersRunning,  int containersPaused,  int containersStopped,  int images,  String driver,  int nCPU,  int memTotal,  String name,  String serverVersion)  $default,) {final _that = this;
 switch (_that) {
 case _DockerInfo():
-return $default(_that.id,_that.containers,_that.containersRunning,_that.containersPaused,_that.containersStopped,_that.images,_that.driver,_that.ncpu,_that.memTotal,_that.name,_that.serverVersion);case _:
+return $default(_that.id,_that.containers,_that.containersRunning,_that.containersPaused,_that.containersStopped,_that.images,_that.driver,_that.nCPU,_that.memTotal,_that.name,_that.serverVersion);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -5559,10 +5258,10 @@ return $default(_that.id,_that.containers,_that.containersRunning,_that.containe
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  int containers,  int containersRunning,  int containersPaused,  int containersStopped,  int images,  String driver,  int ncpu,  int memTotal,  String name,  String serverVersion)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: "ID")  String id,  int containers,  int containersRunning,  int containersPaused,  int containersStopped,  int images,  String driver,  int nCPU,  int memTotal,  String name,  String serverVersion)?  $default,) {final _that = this;
 switch (_that) {
 case _DockerInfo() when $default != null:
-return $default(_that.id,_that.containers,_that.containersRunning,_that.containersPaused,_that.containersStopped,_that.images,_that.driver,_that.ncpu,_that.memTotal,_that.name,_that.serverVersion);case _:
+return $default(_that.id,_that.containers,_that.containersRunning,_that.containersPaused,_that.containersStopped,_that.images,_that.driver,_that.nCPU,_that.memTotal,_that.name,_that.serverVersion);case _:
   return null;
 
 }
@@ -5571,20 +5270,20 @@ return $default(_that.id,_that.containers,_that.containersRunning,_that.containe
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _DockerInfo implements DockerInfo {
-  const _DockerInfo({required this.id, required this.containers, required this.containersRunning, required this.containersPaused, required this.containersStopped, required this.images, required this.driver, required this.ncpu, required this.memTotal, required this.name, required this.serverVersion});
+  const _DockerInfo({@JsonKey(name: "ID") required this.id, required this.containers, required this.containersRunning, required this.containersPaused, required this.containersStopped, required this.images, required this.driver, required this.nCPU, required this.memTotal, required this.name, required this.serverVersion});
   factory _DockerInfo.fromJson(Map<String, dynamic> json) => _$DockerInfoFromJson(json);
 
-@override final  String id;
+@override@JsonKey(name: "ID") final  String id;
 @override final  int containers;
 @override final  int containersRunning;
 @override final  int containersPaused;
 @override final  int containersStopped;
 @override final  int images;
 @override final  String driver;
-@override final  int ncpu;
+@override final  int nCPU;
 @override final  int memTotal;
 @override final  String name;
 @override final  String serverVersion;
@@ -5602,16 +5301,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DockerInfo&&(identical(other.id, id) || other.id == id)&&(identical(other.containers, containers) || other.containers == containers)&&(identical(other.containersRunning, containersRunning) || other.containersRunning == containersRunning)&&(identical(other.containersPaused, containersPaused) || other.containersPaused == containersPaused)&&(identical(other.containersStopped, containersStopped) || other.containersStopped == containersStopped)&&(identical(other.images, images) || other.images == images)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.ncpu, ncpu) || other.ncpu == ncpu)&&(identical(other.memTotal, memTotal) || other.memTotal == memTotal)&&(identical(other.name, name) || other.name == name)&&(identical(other.serverVersion, serverVersion) || other.serverVersion == serverVersion));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DockerInfo&&(identical(other.id, id) || other.id == id)&&(identical(other.containers, containers) || other.containers == containers)&&(identical(other.containersRunning, containersRunning) || other.containersRunning == containersRunning)&&(identical(other.containersPaused, containersPaused) || other.containersPaused == containersPaused)&&(identical(other.containersStopped, containersStopped) || other.containersStopped == containersStopped)&&(identical(other.images, images) || other.images == images)&&(identical(other.driver, driver) || other.driver == driver)&&(identical(other.nCPU, nCPU) || other.nCPU == nCPU)&&(identical(other.memTotal, memTotal) || other.memTotal == memTotal)&&(identical(other.name, name) || other.name == name)&&(identical(other.serverVersion, serverVersion) || other.serverVersion == serverVersion));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,containers,containersRunning,containersPaused,containersStopped,images,driver,ncpu,memTotal,name,serverVersion);
+int get hashCode => Object.hash(runtimeType,id,containers,containersRunning,containersPaused,containersStopped,images,driver,nCPU,memTotal,name,serverVersion);
 
 @override
 String toString() {
-  return 'DockerInfo(id: $id, containers: $containers, containersRunning: $containersRunning, containersPaused: $containersPaused, containersStopped: $containersStopped, images: $images, driver: $driver, ncpu: $ncpu, memTotal: $memTotal, name: $name, serverVersion: $serverVersion)';
+  return 'DockerInfo(id: $id, containers: $containers, containersRunning: $containersRunning, containersPaused: $containersPaused, containersStopped: $containersStopped, images: $images, driver: $driver, nCPU: $nCPU, memTotal: $memTotal, name: $name, serverVersion: $serverVersion)';
 }
 
 
@@ -5622,7 +5321,7 @@ abstract mixin class _$DockerInfoCopyWith<$Res> implements $DockerInfoCopyWith<$
   factory _$DockerInfoCopyWith(_DockerInfo value, $Res Function(_DockerInfo) _then) = __$DockerInfoCopyWithImpl;
 @override @useResult
 $Res call({
- String id, int containers, int containersRunning, int containersPaused, int containersStopped, int images, String driver, int ncpu, int memTotal, String name, String serverVersion
+@JsonKey(name: "ID") String id, int containers, int containersRunning, int containersPaused, int containersStopped, int images, String driver, int nCPU, int memTotal, String name, String serverVersion
 });
 
 
@@ -5639,7 +5338,7 @@ class __$DockerInfoCopyWithImpl<$Res>
 
 /// Create a copy of DockerInfo
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? containers = null,Object? containersRunning = null,Object? containersPaused = null,Object? containersStopped = null,Object? images = null,Object? driver = null,Object? ncpu = null,Object? memTotal = null,Object? name = null,Object? serverVersion = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? containers = null,Object? containersRunning = null,Object? containersPaused = null,Object? containersStopped = null,Object? images = null,Object? driver = null,Object? nCPU = null,Object? memTotal = null,Object? name = null,Object? serverVersion = null,}) {
   return _then(_DockerInfo(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,containers: null == containers ? _self.containers : containers // ignore: cast_nullable_to_non_nullable
@@ -5648,7 +5347,7 @@ as int,containersPaused: null == containersPaused ? _self.containersPaused : con
 as int,containersStopped: null == containersStopped ? _self.containersStopped : containersStopped // ignore: cast_nullable_to_non_nullable
 as int,images: null == images ? _self.images : images // ignore: cast_nullable_to_non_nullable
 as int,driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
-as String,ncpu: null == ncpu ? _self.ncpu : ncpu // ignore: cast_nullable_to_non_nullable
+as String,nCPU: null == nCPU ? _self.nCPU : nCPU // ignore: cast_nullable_to_non_nullable
 as int,memTotal: null == memTotal ? _self.memTotal : memTotal // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,serverVersion: null == serverVersion ? _self.serverVersion : serverVersion // ignore: cast_nullable_to_non_nullable
@@ -5663,7 +5362,7 @@ as String,
 /// @nodoc
 mixin _$DockerVersionInfo {
 
- String get version; String get apiVersion; String get minApiVersion; String get gitCommit; String get goVersion; String get os; String get arch; String get kernelVersion; String get buildTime;
+ String get version; String get apiVersion; String get minAPIVersion; String get gitCommit; String get goVersion; String get os; String get arch; String get kernelVersion; String get buildTime;
 /// Create a copy of DockerVersionInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -5676,16 +5375,16 @@ $DockerVersionInfoCopyWith<DockerVersionInfo> get copyWith => _$DockerVersionInf
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is DockerVersionInfo&&(identical(other.version, version) || other.version == version)&&(identical(other.apiVersion, apiVersion) || other.apiVersion == apiVersion)&&(identical(other.minApiVersion, minApiVersion) || other.minApiVersion == minApiVersion)&&(identical(other.gitCommit, gitCommit) || other.gitCommit == gitCommit)&&(identical(other.goVersion, goVersion) || other.goVersion == goVersion)&&(identical(other.os, os) || other.os == os)&&(identical(other.arch, arch) || other.arch == arch)&&(identical(other.kernelVersion, kernelVersion) || other.kernelVersion == kernelVersion)&&(identical(other.buildTime, buildTime) || other.buildTime == buildTime));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DockerVersionInfo&&(identical(other.version, version) || other.version == version)&&(identical(other.apiVersion, apiVersion) || other.apiVersion == apiVersion)&&(identical(other.minAPIVersion, minAPIVersion) || other.minAPIVersion == minAPIVersion)&&(identical(other.gitCommit, gitCommit) || other.gitCommit == gitCommit)&&(identical(other.goVersion, goVersion) || other.goVersion == goVersion)&&(identical(other.os, os) || other.os == os)&&(identical(other.arch, arch) || other.arch == arch)&&(identical(other.kernelVersion, kernelVersion) || other.kernelVersion == kernelVersion)&&(identical(other.buildTime, buildTime) || other.buildTime == buildTime));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,version,apiVersion,minApiVersion,gitCommit,goVersion,os,arch,kernelVersion,buildTime);
+int get hashCode => Object.hash(runtimeType,version,apiVersion,minAPIVersion,gitCommit,goVersion,os,arch,kernelVersion,buildTime);
 
 @override
 String toString() {
-  return 'DockerVersionInfo(version: $version, apiVersion: $apiVersion, minApiVersion: $minApiVersion, gitCommit: $gitCommit, goVersion: $goVersion, os: $os, arch: $arch, kernelVersion: $kernelVersion, buildTime: $buildTime)';
+  return 'DockerVersionInfo(version: $version, apiVersion: $apiVersion, minAPIVersion: $minAPIVersion, gitCommit: $gitCommit, goVersion: $goVersion, os: $os, arch: $arch, kernelVersion: $kernelVersion, buildTime: $buildTime)';
 }
 
 
@@ -5696,7 +5395,7 @@ abstract mixin class $DockerVersionInfoCopyWith<$Res>  {
   factory $DockerVersionInfoCopyWith(DockerVersionInfo value, $Res Function(DockerVersionInfo) _then) = _$DockerVersionInfoCopyWithImpl;
 @useResult
 $Res call({
- String version, String apiVersion, String minApiVersion, String gitCommit, String goVersion, String os, String arch, String kernelVersion, String buildTime
+ String version, String apiVersion, String minAPIVersion, String gitCommit, String goVersion, String os, String arch, String kernelVersion, String buildTime
 });
 
 
@@ -5713,11 +5412,11 @@ class _$DockerVersionInfoCopyWithImpl<$Res>
 
 /// Create a copy of DockerVersionInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? version = null,Object? apiVersion = null,Object? minApiVersion = null,Object? gitCommit = null,Object? goVersion = null,Object? os = null,Object? arch = null,Object? kernelVersion = null,Object? buildTime = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? version = null,Object? apiVersion = null,Object? minAPIVersion = null,Object? gitCommit = null,Object? goVersion = null,Object? os = null,Object? arch = null,Object? kernelVersion = null,Object? buildTime = null,}) {
   return _then(_self.copyWith(
 version: null == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
 as String,apiVersion: null == apiVersion ? _self.apiVersion : apiVersion // ignore: cast_nullable_to_non_nullable
-as String,minApiVersion: null == minApiVersion ? _self.minApiVersion : minApiVersion // ignore: cast_nullable_to_non_nullable
+as String,minAPIVersion: null == minAPIVersion ? _self.minAPIVersion : minAPIVersion // ignore: cast_nullable_to_non_nullable
 as String,gitCommit: null == gitCommit ? _self.gitCommit : gitCommit // ignore: cast_nullable_to_non_nullable
 as String,goVersion: null == goVersion ? _self.goVersion : goVersion // ignore: cast_nullable_to_non_nullable
 as String,os: null == os ? _self.os : os // ignore: cast_nullable_to_non_nullable
@@ -5809,10 +5508,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String version,  String apiVersion,  String minApiVersion,  String gitCommit,  String goVersion,  String os,  String arch,  String kernelVersion,  String buildTime)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String version,  String apiVersion,  String minAPIVersion,  String gitCommit,  String goVersion,  String os,  String arch,  String kernelVersion,  String buildTime)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _DockerVersionInfo() when $default != null:
-return $default(_that.version,_that.apiVersion,_that.minApiVersion,_that.gitCommit,_that.goVersion,_that.os,_that.arch,_that.kernelVersion,_that.buildTime);case _:
+return $default(_that.version,_that.apiVersion,_that.minAPIVersion,_that.gitCommit,_that.goVersion,_that.os,_that.arch,_that.kernelVersion,_that.buildTime);case _:
   return orElse();
 
 }
@@ -5830,10 +5529,10 @@ return $default(_that.version,_that.apiVersion,_that.minApiVersion,_that.gitComm
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String version,  String apiVersion,  String minApiVersion,  String gitCommit,  String goVersion,  String os,  String arch,  String kernelVersion,  String buildTime)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String version,  String apiVersion,  String minAPIVersion,  String gitCommit,  String goVersion,  String os,  String arch,  String kernelVersion,  String buildTime)  $default,) {final _that = this;
 switch (_that) {
 case _DockerVersionInfo():
-return $default(_that.version,_that.apiVersion,_that.minApiVersion,_that.gitCommit,_that.goVersion,_that.os,_that.arch,_that.kernelVersion,_that.buildTime);case _:
+return $default(_that.version,_that.apiVersion,_that.minAPIVersion,_that.gitCommit,_that.goVersion,_that.os,_that.arch,_that.kernelVersion,_that.buildTime);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -5850,10 +5549,10 @@ return $default(_that.version,_that.apiVersion,_that.minApiVersion,_that.gitComm
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String version,  String apiVersion,  String minApiVersion,  String gitCommit,  String goVersion,  String os,  String arch,  String kernelVersion,  String buildTime)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String version,  String apiVersion,  String minAPIVersion,  String gitCommit,  String goVersion,  String os,  String arch,  String kernelVersion,  String buildTime)?  $default,) {final _that = this;
 switch (_that) {
 case _DockerVersionInfo() when $default != null:
-return $default(_that.version,_that.apiVersion,_that.minApiVersion,_that.gitCommit,_that.goVersion,_that.os,_that.arch,_that.kernelVersion,_that.buildTime);case _:
+return $default(_that.version,_that.apiVersion,_that.minAPIVersion,_that.gitCommit,_that.goVersion,_that.os,_that.arch,_that.kernelVersion,_that.buildTime);case _:
   return null;
 
 }
@@ -5862,15 +5561,15 @@ return $default(_that.version,_that.apiVersion,_that.minApiVersion,_that.gitComm
 }
 
 /// @nodoc
-@JsonSerializable()
 
+@JsonSerializable(fieldRename: FieldRename.pascal)
 class _DockerVersionInfo implements DockerVersionInfo {
-  const _DockerVersionInfo({required this.version, required this.apiVersion, required this.minApiVersion, required this.gitCommit, required this.goVersion, required this.os, required this.arch, required this.kernelVersion, required this.buildTime});
+  const _DockerVersionInfo({required this.version, required this.apiVersion, required this.minAPIVersion, required this.gitCommit, required this.goVersion, required this.os, required this.arch, required this.kernelVersion, required this.buildTime});
   factory _DockerVersionInfo.fromJson(Map<String, dynamic> json) => _$DockerVersionInfoFromJson(json);
 
 @override final  String version;
 @override final  String apiVersion;
-@override final  String minApiVersion;
+@override final  String minAPIVersion;
 @override final  String gitCommit;
 @override final  String goVersion;
 @override final  String os;
@@ -5891,16 +5590,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DockerVersionInfo&&(identical(other.version, version) || other.version == version)&&(identical(other.apiVersion, apiVersion) || other.apiVersion == apiVersion)&&(identical(other.minApiVersion, minApiVersion) || other.minApiVersion == minApiVersion)&&(identical(other.gitCommit, gitCommit) || other.gitCommit == gitCommit)&&(identical(other.goVersion, goVersion) || other.goVersion == goVersion)&&(identical(other.os, os) || other.os == os)&&(identical(other.arch, arch) || other.arch == arch)&&(identical(other.kernelVersion, kernelVersion) || other.kernelVersion == kernelVersion)&&(identical(other.buildTime, buildTime) || other.buildTime == buildTime));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DockerVersionInfo&&(identical(other.version, version) || other.version == version)&&(identical(other.apiVersion, apiVersion) || other.apiVersion == apiVersion)&&(identical(other.minAPIVersion, minAPIVersion) || other.minAPIVersion == minAPIVersion)&&(identical(other.gitCommit, gitCommit) || other.gitCommit == gitCommit)&&(identical(other.goVersion, goVersion) || other.goVersion == goVersion)&&(identical(other.os, os) || other.os == os)&&(identical(other.arch, arch) || other.arch == arch)&&(identical(other.kernelVersion, kernelVersion) || other.kernelVersion == kernelVersion)&&(identical(other.buildTime, buildTime) || other.buildTime == buildTime));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,version,apiVersion,minApiVersion,gitCommit,goVersion,os,arch,kernelVersion,buildTime);
+int get hashCode => Object.hash(runtimeType,version,apiVersion,minAPIVersion,gitCommit,goVersion,os,arch,kernelVersion,buildTime);
 
 @override
 String toString() {
-  return 'DockerVersionInfo(version: $version, apiVersion: $apiVersion, minApiVersion: $minApiVersion, gitCommit: $gitCommit, goVersion: $goVersion, os: $os, arch: $arch, kernelVersion: $kernelVersion, buildTime: $buildTime)';
+  return 'DockerVersionInfo(version: $version, apiVersion: $apiVersion, minAPIVersion: $minAPIVersion, gitCommit: $gitCommit, goVersion: $goVersion, os: $os, arch: $arch, kernelVersion: $kernelVersion, buildTime: $buildTime)';
 }
 
 
@@ -5911,7 +5610,7 @@ abstract mixin class _$DockerVersionInfoCopyWith<$Res> implements $DockerVersion
   factory _$DockerVersionInfoCopyWith(_DockerVersionInfo value, $Res Function(_DockerVersionInfo) _then) = __$DockerVersionInfoCopyWithImpl;
 @override @useResult
 $Res call({
- String version, String apiVersion, String minApiVersion, String gitCommit, String goVersion, String os, String arch, String kernelVersion, String buildTime
+ String version, String apiVersion, String minAPIVersion, String gitCommit, String goVersion, String os, String arch, String kernelVersion, String buildTime
 });
 
 
@@ -5928,11 +5627,11 @@ class __$DockerVersionInfoCopyWithImpl<$Res>
 
 /// Create a copy of DockerVersionInfo
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? version = null,Object? apiVersion = null,Object? minApiVersion = null,Object? gitCommit = null,Object? goVersion = null,Object? os = null,Object? arch = null,Object? kernelVersion = null,Object? buildTime = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? version = null,Object? apiVersion = null,Object? minAPIVersion = null,Object? gitCommit = null,Object? goVersion = null,Object? os = null,Object? arch = null,Object? kernelVersion = null,Object? buildTime = null,}) {
   return _then(_DockerVersionInfo(
 version: null == version ? _self.version : version // ignore: cast_nullable_to_non_nullable
 as String,apiVersion: null == apiVersion ? _self.apiVersion : apiVersion // ignore: cast_nullable_to_non_nullable
-as String,minApiVersion: null == minApiVersion ? _self.minApiVersion : minApiVersion // ignore: cast_nullable_to_non_nullable
+as String,minAPIVersion: null == minAPIVersion ? _self.minAPIVersion : minAPIVersion // ignore: cast_nullable_to_non_nullable
 as String,gitCommit: null == gitCommit ? _self.gitCommit : gitCommit // ignore: cast_nullable_to_non_nullable
 as String,goVersion: null == goVersion ? _self.goVersion : goVersion // ignore: cast_nullable_to_non_nullable
 as String,os: null == os ? _self.os : os // ignore: cast_nullable_to_non_nullable

--- a/lib/data/services/api/models/environment/environment.g.dart
+++ b/lib/data/services/api/models/environment/environment.g.dart
@@ -7,200 +7,202 @@ part of 'environment.dart';
 // **************************************************************************
 
 _Environment _$EnvironmentFromJson(Map<String, dynamic> json) => _Environment(
-  id: (json['id'] as num).toInt(),
-  name: json['name'] as String,
-  type: (json['type'] as num).toInt(),
-  containerEngine: json['containerEngine'] as String,
-  url: json['url'] as String,
-  groupId: (json['groupId'] as num).toInt(),
-  publicUrl: json['publicUrl'] as String,
-  gpus: (json['gpus'] as List<dynamic>).map((e) => e as String).toList(),
-  tlsConfig: TLSConfig.fromJson(json['tlsConfig'] as Map<String, dynamic>),
+  id: (json['Id'] as num).toInt(),
+  name: json['Name'] as String,
+  type: (json['Type'] as num).toInt(),
+  containerEngine: json['ContainerEngine'] as String?,
+  uRL: json['URL'] as String,
+  groupId: (json['GroupId'] as num).toInt(),
+  publicUrl: json['PublicUrl'] as String?,
+  gpus: (json['Gpus'] as List<dynamic>?)?.map((e) => e as String).toList(),
+  tlsConfig: json['TlsConfig'] == null
+      ? null
+      : TLSConfig.fromJson(json['TlsConfig'] as Map<String, dynamic>),
   azureCredentials: AzureCredentials.fromJson(
-    json['azureCredentials'] as Map<String, dynamic>,
+    json['AzureCredentials'] as Map<String, dynamic>,
   ),
-  tagIds: (json['tagIds'] as List<dynamic>)
-      .map((e) => (e as num).toInt())
+  tagIds: (json['TagIds'] as List<dynamic>?)
+      ?.map((e) => (e as num).toInt())
       .toList(),
-  status: (json['status'] as num).toInt(),
-  snapshots: (json['snapshots'] as List<dynamic>)
+  status: (json['Status'] as num).toInt(),
+  snapshots: (json['Snapshots'] as List<dynamic>)
       .map((e) => Snapshot.fromJson(e as Map<String, dynamic>))
       .toList(),
 );
 
 Map<String, dynamic> _$EnvironmentToJson(_Environment instance) =>
     <String, dynamic>{
-      'id': instance.id,
-      'name': instance.name,
-      'type': instance.type,
-      'containerEngine': instance.containerEngine,
-      'url': instance.url,
-      'groupId': instance.groupId,
-      'publicUrl': instance.publicUrl,
-      'gpus': instance.gpus,
-      'tlsConfig': instance.tlsConfig,
-      'azureCredentials': instance.azureCredentials,
-      'tagIds': instance.tagIds,
-      'status': instance.status,
-      'snapshots': instance.snapshots,
+      'Id': instance.id,
+      'Name': instance.name,
+      'Type': instance.type,
+      'ContainerEngine': instance.containerEngine,
+      'URL': instance.uRL,
+      'GroupId': instance.groupId,
+      'PublicUrl': instance.publicUrl,
+      'Gpus': instance.gpus,
+      'TlsConfig': instance.tlsConfig,
+      'AzureCredentials': instance.azureCredentials,
+      'TagIds': instance.tagIds,
+      'Status': instance.status,
+      'Snapshots': instance.snapshots,
     };
 
 _TLSConfig _$TLSConfigFromJson(Map<String, dynamic> json) => _TLSConfig(
-  tls: json['tls'] as bool,
-  tlsSkipVerify: json['tlsSkipVerify'] as bool,
+  tls: json['Tls'] as bool,
+  tlsSkipVerify: json['TlsSkipVerify'] as bool,
 );
 
 Map<String, dynamic> _$TLSConfigToJson(_TLSConfig instance) =>
     <String, dynamic>{
-      'tls': instance.tls,
-      'tlsSkipVerify': instance.tlsSkipVerify,
+      'Tls': instance.tls,
+      'TlsSkipVerify': instance.tlsSkipVerify,
     };
 
 _AzureCredentials _$AzureCredentialsFromJson(Map<String, dynamic> json) =>
     _AzureCredentials(
-      applicationId: json['applicationId'] as String,
-      tenantId: json['tenantId'] as String,
-      authenticationKey: json['authenticationKey'] as String,
+      applicationID: json['ApplicationID'] as String?,
+      tenantID: json['TenantID'] as String?,
+      authenticationKey: json['AuthenticationKey'] as String?,
     );
 
 Map<String, dynamic> _$AzureCredentialsToJson(_AzureCredentials instance) =>
     <String, dynamic>{
-      'applicationId': instance.applicationId,
-      'tenantId': instance.tenantId,
-      'authenticationKey': instance.authenticationKey,
+      'ApplicationID': instance.applicationID,
+      'TenantID': instance.tenantID,
+      'AuthenticationKey': instance.authenticationKey,
     };
 
 _Snapshot _$SnapshotFromJson(Map<String, dynamic> json) => _Snapshot(
-  time: (json['time'] as num).toInt(),
-  dockerVersion: json['dockerVersion'] as String,
-  swarm: json['swarm'] as bool,
-  totalCpu: (json['totalCpu'] as num).toInt(),
-  totalMemory: (json['totalMemory'] as num).toInt(),
-  containerCount: (json['containerCount'] as num).toInt(),
-  runningContainerCount: (json['runningContainerCount'] as num).toInt(),
-  stoppedContainerCount: (json['stoppedContainerCount'] as num).toInt(),
-  healthyContainerCount: (json['healthyContainerCount'] as num).toInt(),
-  unhealthyContainerCount: (json['unhealthyContainerCount'] as num).toInt(),
-  volumeCount: (json['volumeCount'] as num).toInt(),
-  imageCount: (json['imageCount'] as num).toInt(),
-  serviceCount: (json['serviceCount'] as num).toInt(),
-  stackCount: (json['stackCount'] as num).toInt(),
+  time: (json['Time'] as num).toInt(),
+  dockerVersion: json['DockerVersion'] as String,
+  swarm: json['Swarm'] as bool,
+  totalCPU: (json['TotalCPU'] as num).toInt(),
+  totalMemory: (json['TotalMemory'] as num).toInt(),
+  containerCount: (json['ContainerCount'] as num).toInt(),
+  runningContainerCount: (json['RunningContainerCount'] as num).toInt(),
+  stoppedContainerCount: (json['StoppedContainerCount'] as num).toInt(),
+  healthyContainerCount: (json['HealthyContainerCount'] as num).toInt(),
+  unhealthyContainerCount: (json['UnhealthyContainerCount'] as num).toInt(),
+  volumeCount: (json['VolumeCount'] as num).toInt(),
+  imageCount: (json['ImageCount'] as num).toInt(),
+  serviceCount: (json['ServiceCount'] as num).toInt(),
+  stackCount: (json['StackCount'] as num).toInt(),
   dockerSnapshotRaw: DockerSnapshotRaw.fromJson(
-    json['dockerSnapshotRaw'] as Map<String, dynamic>,
+    json['DockerSnapshotRaw'] as Map<String, dynamic>,
   ),
 );
 
 Map<String, dynamic> _$SnapshotToJson(_Snapshot instance) => <String, dynamic>{
-  'time': instance.time,
-  'dockerVersion': instance.dockerVersion,
-  'swarm': instance.swarm,
-  'totalCpu': instance.totalCpu,
-  'totalMemory': instance.totalMemory,
-  'containerCount': instance.containerCount,
-  'runningContainerCount': instance.runningContainerCount,
-  'stoppedContainerCount': instance.stoppedContainerCount,
-  'healthyContainerCount': instance.healthyContainerCount,
-  'unhealthyContainerCount': instance.unhealthyContainerCount,
-  'volumeCount': instance.volumeCount,
-  'imageCount': instance.imageCount,
-  'serviceCount': instance.serviceCount,
-  'stackCount': instance.stackCount,
-  'dockerSnapshotRaw': instance.dockerSnapshotRaw,
+  'Time': instance.time,
+  'DockerVersion': instance.dockerVersion,
+  'Swarm': instance.swarm,
+  'TotalCPU': instance.totalCPU,
+  'TotalMemory': instance.totalMemory,
+  'ContainerCount': instance.containerCount,
+  'RunningContainerCount': instance.runningContainerCount,
+  'StoppedContainerCount': instance.stoppedContainerCount,
+  'HealthyContainerCount': instance.healthyContainerCount,
+  'UnhealthyContainerCount': instance.unhealthyContainerCount,
+  'VolumeCount': instance.volumeCount,
+  'ImageCount': instance.imageCount,
+  'ServiceCount': instance.serviceCount,
+  'StackCount': instance.stackCount,
+  'DockerSnapshotRaw': instance.dockerSnapshotRaw,
 };
 
 _DockerSnapshotRaw _$DockerSnapshotRawFromJson(Map<String, dynamic> json) =>
     _DockerSnapshotRaw(
-      containers: (json['containers'] as List<dynamic>)
+      containers: (json['Containers'] as List<dynamic>)
           .map((e) => ContainerInfo.fromJson(e as Map<String, dynamic>))
           .toList(),
-      volumes: VolumeData.fromJson(json['volumes'] as Map<String, dynamic>),
-      networks: (json['networks'] as List<dynamic>)
+      volumes: VolumeData.fromJson(json['Volumes'] as Map<String, dynamic>),
+      networks: (json['Networks'] as List<dynamic>)
           .map((e) => NetworkInfo.fromJson(e as Map<String, dynamic>))
           .toList(),
-      images: (json['images'] as List<dynamic>)
+      images: (json['Images'] as List<dynamic>)
           .map((e) => ImageInfo.fromJson(e as Map<String, dynamic>))
           .toList(),
-      info: DockerInfo.fromJson(json['info'] as Map<String, dynamic>),
+      info: DockerInfo.fromJson(json['Info'] as Map<String, dynamic>),
       version: DockerVersionInfo.fromJson(
-        json['version'] as Map<String, dynamic>,
+        json['Version'] as Map<String, dynamic>,
       ),
     );
 
 Map<String, dynamic> _$DockerSnapshotRawToJson(_DockerSnapshotRaw instance) =>
     <String, dynamic>{
-      'containers': instance.containers,
-      'volumes': instance.volumes,
-      'networks': instance.networks,
-      'images': instance.images,
-      'info': instance.info,
-      'version': instance.version,
+      'Containers': instance.containers,
+      'Volumes': instance.volumes,
+      'Networks': instance.networks,
+      'Images': instance.images,
+      'Info': instance.info,
+      'Version': instance.version,
     };
 
 _ContainerInfo _$ContainerInfoFromJson(Map<String, dynamic> json) =>
     _ContainerInfo(
-      id: json['id'] as String,
-      names: (json['names'] as List<dynamic>).map((e) => e as String).toList(),
-      image: json['image'] as String,
-      imageId: json['imageId'] as String,
-      command: json['command'] as String,
-      created: (json['created'] as num).toInt(),
-      ports: (json['ports'] as List<dynamic>)
+      id: json['Id'] as String,
+      names: (json['Names'] as List<dynamic>).map((e) => e as String).toList(),
+      image: json['Image'] as String,
+      imageID: json['ImageID'] as String,
+      command: json['Command'] as String,
+      created: (json['Created'] as num).toInt(),
+      ports: (json['Ports'] as List<dynamic>)
           .map((e) => PortInfo.fromJson(e as Map<String, dynamic>))
           .toList(),
-      labels: Map<String, String>.from(json['labels'] as Map),
-      state: json['state'] as String,
-      status: json['status'] as String,
+      labels: Map<String, String>.from(json['Labels'] as Map),
+      state: json['State'] as String,
+      status: json['Status'] as String,
       hostConfig: HostConfigInfo.fromJson(
-        json['hostConfig'] as Map<String, dynamic>,
+        json['HostConfig'] as Map<String, dynamic>,
       ),
       networkSettings: NetworkSettingsInfo.fromJson(
-        json['networkSettings'] as Map<String, dynamic>,
+        json['NetworkSettings'] as Map<String, dynamic>,
       ),
-      mounts: (json['mounts'] as List<dynamic>)
+      mounts: (json['Mounts'] as List<dynamic>)
           .map((e) => MountInfo.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
 Map<String, dynamic> _$ContainerInfoToJson(_ContainerInfo instance) =>
     <String, dynamic>{
-      'id': instance.id,
-      'names': instance.names,
-      'image': instance.image,
-      'imageId': instance.imageId,
-      'command': instance.command,
-      'created': instance.created,
-      'ports': instance.ports,
-      'labels': instance.labels,
-      'state': instance.state,
-      'status': instance.status,
-      'hostConfig': instance.hostConfig,
-      'networkSettings': instance.networkSettings,
-      'mounts': instance.mounts,
+      'Id': instance.id,
+      'Names': instance.names,
+      'Image': instance.image,
+      'ImageID': instance.imageID,
+      'Command': instance.command,
+      'Created': instance.created,
+      'Ports': instance.ports,
+      'Labels': instance.labels,
+      'State': instance.state,
+      'Status': instance.status,
+      'HostConfig': instance.hostConfig,
+      'NetworkSettings': instance.networkSettings,
+      'Mounts': instance.mounts,
     };
 
 _PortInfo _$PortInfoFromJson(Map<String, dynamic> json) => _PortInfo(
-  ip: json['ip'] as String?,
-  privatePort: (json['privatePort'] as num).toInt(),
-  publicPort: (json['publicPort'] as num?)?.toInt(),
-  type: json['type'] as String,
+  ip: json['Ip'] as String?,
+  privatePort: (json['PrivatePort'] as num).toInt(),
+  publicPort: (json['PublicPort'] as num?)?.toInt(),
+  type: json['Type'] as String,
 );
 
 Map<String, dynamic> _$PortInfoToJson(_PortInfo instance) => <String, dynamic>{
-  'ip': instance.ip,
-  'privatePort': instance.privatePort,
-  'publicPort': instance.publicPort,
-  'type': instance.type,
+  'Ip': instance.ip,
+  'PrivatePort': instance.privatePort,
+  'PublicPort': instance.publicPort,
+  'Type': instance.type,
 };
 
 _HostConfigInfo _$HostConfigInfoFromJson(Map<String, dynamic> json) =>
-    _HostConfigInfo(networkMode: json['networkMode'] as String);
+    _HostConfigInfo(networkMode: json['NetworkMode'] as String);
 
 Map<String, dynamic> _$HostConfigInfoToJson(_HostConfigInfo instance) =>
-    <String, dynamic>{'networkMode': instance.networkMode};
+    <String, dynamic>{'NetworkMode': instance.networkMode};
 
 _NetworkSettingsInfo _$NetworkSettingsInfoFromJson(Map<String, dynamic> json) =>
     _NetworkSettingsInfo(
-      networks: (json['networks'] as Map<String, dynamic>).map(
+      networks: (json['Networks'] as Map<String, dynamic>).map(
         (k, e) =>
             MapEntry(k, NetworkDetailInfo.fromJson(e as Map<String, dynamic>)),
       ),
@@ -208,253 +210,233 @@ _NetworkSettingsInfo _$NetworkSettingsInfoFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$NetworkSettingsInfoToJson(
   _NetworkSettingsInfo instance,
-) => <String, dynamic>{'networks': instance.networks};
+) => <String, dynamic>{'Networks': instance.networks};
 
 _NetworkDetailInfo _$NetworkDetailInfoFromJson(Map<String, dynamic> json) =>
     _NetworkDetailInfo(
-      ipamConfig: json['ipamConfig'],
-      links: json['links'],
-      aliases: json['aliases'],
-      macAddress: json['macAddress'] as String,
-      driverOpts: json['driverOpts'],
-      networkId: json['networkId'] as String,
-      endpointId: json['endpointId'] as String,
-      gateway: json['gateway'] as String,
-      ipAddress: json['ipAddress'] as String,
-      ipPrefixLen: (json['ipPrefixLen'] as num).toInt(),
-      ipv6Gateway: json['ipv6Gateway'] as String,
-      globalIpv6Address: json['globalIpv6Address'] as String,
-      globalIpv6PrefixLen: (json['globalIpv6PrefixLen'] as num).toInt(),
-      dnsNames: json['dnsNames'],
+      ipamConfig: json['IpamConfig'],
+      links: json['Links'],
+      aliases: json['Aliases'],
+      macAddress: json['MacAddress'] as String,
+      driverOpts: json['DriverOpts'],
+      networkID: json['NetworkID'] as String,
+      endpointID: json['EndpointID'] as String,
+      gateway: json['Gateway'] as String,
+      iPAddress: json['IPAddress'] as String,
+      iPPrefixLen: (json['IPPrefixLen'] as num?)?.toInt(),
+      iPv6Gateway: json['IPv6Gateway'] as String?,
+      globalIPv6Address: json['GlobalIPv6Address'] as String?,
+      globalIPv6PrefixLen: (json['GlobalIPv6PrefixLen'] as num?)?.toInt(),
+      dnsNames: json['DnsNames'],
     );
 
 Map<String, dynamic> _$NetworkDetailInfoToJson(_NetworkDetailInfo instance) =>
     <String, dynamic>{
-      'ipamConfig': instance.ipamConfig,
-      'links': instance.links,
-      'aliases': instance.aliases,
-      'macAddress': instance.macAddress,
-      'driverOpts': instance.driverOpts,
-      'networkId': instance.networkId,
-      'endpointId': instance.endpointId,
-      'gateway': instance.gateway,
-      'ipAddress': instance.ipAddress,
-      'ipPrefixLen': instance.ipPrefixLen,
-      'ipv6Gateway': instance.ipv6Gateway,
-      'globalIpv6Address': instance.globalIpv6Address,
-      'globalIpv6PrefixLen': instance.globalIpv6PrefixLen,
-      'dnsNames': instance.dnsNames,
+      'IpamConfig': instance.ipamConfig,
+      'Links': instance.links,
+      'Aliases': instance.aliases,
+      'MacAddress': instance.macAddress,
+      'DriverOpts': instance.driverOpts,
+      'NetworkID': instance.networkID,
+      'EndpointID': instance.endpointID,
+      'Gateway': instance.gateway,
+      'IPAddress': instance.iPAddress,
+      'IPPrefixLen': instance.iPPrefixLen,
+      'IPv6Gateway': instance.iPv6Gateway,
+      'GlobalIPv6Address': instance.globalIPv6Address,
+      'GlobalIPv6PrefixLen': instance.globalIPv6PrefixLen,
+      'DnsNames': instance.dnsNames,
     };
 
 _MountInfo _$MountInfoFromJson(Map<String, dynamic> json) => _MountInfo(
-  type: json['type'] as String,
-  name: json['name'] as String?,
-  source: json['source'] as String,
-  destination: json['destination'] as String,
-  driver: json['driver'] as String?,
-  mode: json['mode'] as String,
-  rw: json['rw'] as bool,
-  propagation: json['propagation'] as String,
+  type: json['Type'] as String,
+  name: json['Name'] as String?,
+  source: json['Source'] as String,
+  destination: json['Destination'] as String,
+  driver: json['Driver'] as String?,
+  mode: json['Mode'] as String,
+  rW: json['RW'] as bool,
+  propagation: json['Propagation'] as String?,
 );
 
 Map<String, dynamic> _$MountInfoToJson(_MountInfo instance) =>
     <String, dynamic>{
-      'type': instance.type,
-      'name': instance.name,
-      'source': instance.source,
-      'destination': instance.destination,
-      'driver': instance.driver,
-      'mode': instance.mode,
-      'rw': instance.rw,
-      'propagation': instance.propagation,
+      'Type': instance.type,
+      'Name': instance.name,
+      'Source': instance.source,
+      'Destination': instance.destination,
+      'Driver': instance.driver,
+      'Mode': instance.mode,
+      'RW': instance.rW,
+      'Propagation': instance.propagation,
     };
 
 _VolumeData _$VolumeDataFromJson(Map<String, dynamic> json) => _VolumeData(
-  volumes: (json['volumes'] as List<dynamic>)
+  volumes: (json['Volumes'] as List<dynamic>)
       .map((e) => VolumeInfo.fromJson(e as Map<String, dynamic>))
       .toList(),
-  warnings: json['warnings'],
+  warnings: json['Warnings'],
 );
 
 Map<String, dynamic> _$VolumeDataToJson(_VolumeData instance) =>
     <String, dynamic>{
-      'volumes': instance.volumes,
-      'warnings': instance.warnings,
+      'Volumes': instance.volumes,
+      'Warnings': instance.warnings,
     };
 
 _VolumeInfo _$VolumeInfoFromJson(Map<String, dynamic> json) => _VolumeInfo(
-  createdAt: json['createdAt'] as String,
-  driver: json['driver'] as String,
-  labels: (json['labels'] as Map<String, dynamic>?)?.map(
+  createdAt: json['CreatedAt'] as String,
+  driver: json['Driver'] as String,
+  labels: (json['Labels'] as Map<String, dynamic>?)?.map(
     (k, e) => MapEntry(k, e as String),
   ),
-  mountpoint: json['mountpoint'] as String,
-  name: json['name'] as String,
-  options: (json['options'] as Map<String, dynamic>?)?.map(
-    (k, e) => MapEntry(k, e as String),
-  ),
-  scope: json['scope'] as String,
+  mountpoint: json['Mountpoint'] as String,
+  name: json['Name'] as String,
+  scope: json['Scope'] as String,
 );
 
 Map<String, dynamic> _$VolumeInfoToJson(_VolumeInfo instance) =>
     <String, dynamic>{
-      'createdAt': instance.createdAt,
-      'driver': instance.driver,
-      'labels': instance.labels,
-      'mountpoint': instance.mountpoint,
-      'name': instance.name,
-      'options': instance.options,
-      'scope': instance.scope,
+      'CreatedAt': instance.createdAt,
+      'Driver': instance.driver,
+      'Labels': instance.labels,
+      'Mountpoint': instance.mountpoint,
+      'Name': instance.name,
+      'Scope': instance.scope,
     };
 
 _NetworkInfo _$NetworkInfoFromJson(Map<String, dynamic> json) => _NetworkInfo(
-  name: json['name'] as String,
-  id: json['id'] as String,
-  created: json['created'] as String,
-  scope: json['scope'] as String,
-  driver: json['driver'] as String,
-  enableIpv6: json['enableIpv6'] as bool,
-  ipam: IPAMInfo.fromJson(json['ipam'] as Map<String, dynamic>),
-  internal: json['internal'] as bool,
-  attachable: json['attachable'] as bool,
-  ingress: json['ingress'] as bool,
+  name: json['Name'] as String,
+  id: json['Id'] as String,
+  created: json['Created'] as String,
+  scope: json['Scope'] as String,
+  driver: json['Driver'] as String,
+  enableIPv6: json['EnableIPv6'] as bool,
+  internal: json['Internal'] as bool,
+  attachable: json['Attachable'] as bool,
+  ingress: json['Ingress'] as bool,
   configFrom: ConfigFromInfo.fromJson(
-    json['configFrom'] as Map<String, dynamic>,
+    json['ConfigFrom'] as Map<String, dynamic>,
   ),
-  configOnly: json['configOnly'] as bool,
-  containers: json['containers'] as Map<String, dynamic>,
-  options: json['options'] as Map<String, dynamic>,
-  labels: json['labels'] as Map<String, dynamic>,
+  configOnly: json['ConfigOnly'] as bool,
+  containers: json['Containers'] as Map<String, dynamic>,
+  options: json['Options'] as Map<String, dynamic>?,
+  labels: json['Labels'] as Map<String, dynamic>,
 );
 
 Map<String, dynamic> _$NetworkInfoToJson(_NetworkInfo instance) =>
     <String, dynamic>{
-      'name': instance.name,
-      'id': instance.id,
-      'created': instance.created,
-      'scope': instance.scope,
-      'driver': instance.driver,
-      'enableIpv6': instance.enableIpv6,
-      'ipam': instance.ipam,
-      'internal': instance.internal,
-      'attachable': instance.attachable,
-      'ingress': instance.ingress,
-      'configFrom': instance.configFrom,
-      'configOnly': instance.configOnly,
-      'containers': instance.containers,
-      'options': instance.options,
-      'labels': instance.labels,
+      'Name': instance.name,
+      'Id': instance.id,
+      'Created': instance.created,
+      'Scope': instance.scope,
+      'Driver': instance.driver,
+      'EnableIPv6': instance.enableIPv6,
+      'Internal': instance.internal,
+      'Attachable': instance.attachable,
+      'Ingress': instance.ingress,
+      'ConfigFrom': instance.configFrom,
+      'ConfigOnly': instance.configOnly,
+      'Containers': instance.containers,
+      'Options': instance.options,
+      'Labels': instance.labels,
     };
-
-_IPAMInfo _$IPAMInfoFromJson(Map<String, dynamic> json) => _IPAMInfo(
-  driver: json['driver'] as String,
-  options: json['options'] as Map<String, dynamic>,
-  config: (json['config'] as List<dynamic>)
-      .map((e) => IPAMConfigInfo.fromJson(e as Map<String, dynamic>))
-      .toList(),
-);
-
-Map<String, dynamic> _$IPAMInfoToJson(_IPAMInfo instance) => <String, dynamic>{
-  'driver': instance.driver,
-  'options': instance.options,
-  'config': instance.config,
-};
 
 _IPAMConfigInfo _$IPAMConfigInfoFromJson(Map<String, dynamic> json) =>
     _IPAMConfigInfo(
-      subnet: json['subnet'] as String,
-      gateway: json['gateway'] as String,
+      subnet: json['Subnet'] as String,
+      gateway: json['Gateway'] as String,
     );
 
 Map<String, dynamic> _$IPAMConfigInfoToJson(_IPAMConfigInfo instance) =>
-    <String, dynamic>{'subnet': instance.subnet, 'gateway': instance.gateway};
+    <String, dynamic>{'Subnet': instance.subnet, 'Gateway': instance.gateway};
 
 _ConfigFromInfo _$ConfigFromInfoFromJson(Map<String, dynamic> json) =>
-    _ConfigFromInfo(network: json['network'] as String);
+    _ConfigFromInfo(network: json['Network'] as String);
 
 Map<String, dynamic> _$ConfigFromInfoToJson(_ConfigFromInfo instance) =>
-    <String, dynamic>{'network': instance.network};
+    <String, dynamic>{'Network': instance.network};
 
 _ImageInfo _$ImageInfoFromJson(Map<String, dynamic> json) => _ImageInfo(
-  containers: (json['containers'] as num).toInt(),
-  created: (json['created'] as num).toInt(),
-  id: json['id'] as String,
-  labels: json['labels'] as Map<String, dynamic>?,
-  parentId: json['parentId'] as String,
-  repoDigests: (json['repoDigests'] as List<dynamic>)
+  containers: (json['Containers'] as num).toInt(),
+  created: (json['Created'] as num).toInt(),
+  id: json['Id'] as String,
+  labels: json['Labels'] as Map<String, dynamic>?,
+  parentId: json['ParentId'] as String,
+  repoDigests: (json['RepoDigests'] as List<dynamic>)
       .map((e) => e as String)
       .toList(),
-  repoTags: (json['repoTags'] as List<dynamic>)
+  repoTags: (json['RepoTags'] as List<dynamic>)
       .map((e) => e as String)
       .toList(),
-  sharedSize: (json['sharedSize'] as num).toInt(),
-  size: (json['size'] as num).toInt(),
+  sharedSize: (json['SharedSize'] as num).toInt(),
+  size: (json['Size'] as num).toInt(),
 );
 
 Map<String, dynamic> _$ImageInfoToJson(_ImageInfo instance) =>
     <String, dynamic>{
-      'containers': instance.containers,
-      'created': instance.created,
-      'id': instance.id,
-      'labels': instance.labels,
-      'parentId': instance.parentId,
-      'repoDigests': instance.repoDigests,
-      'repoTags': instance.repoTags,
-      'sharedSize': instance.sharedSize,
-      'size': instance.size,
+      'Containers': instance.containers,
+      'Created': instance.created,
+      'Id': instance.id,
+      'Labels': instance.labels,
+      'ParentId': instance.parentId,
+      'RepoDigests': instance.repoDigests,
+      'RepoTags': instance.repoTags,
+      'SharedSize': instance.sharedSize,
+      'Size': instance.size,
     };
 
 _DockerInfo _$DockerInfoFromJson(Map<String, dynamic> json) => _DockerInfo(
-  id: json['id'] as String,
-  containers: (json['containers'] as num).toInt(),
-  containersRunning: (json['containersRunning'] as num).toInt(),
-  containersPaused: (json['containersPaused'] as num).toInt(),
-  containersStopped: (json['containersStopped'] as num).toInt(),
-  images: (json['images'] as num).toInt(),
-  driver: json['driver'] as String,
-  ncpu: (json['ncpu'] as num).toInt(),
-  memTotal: (json['memTotal'] as num).toInt(),
-  name: json['name'] as String,
-  serverVersion: json['serverVersion'] as String,
+  id: json['ID'] as String,
+  containers: (json['Containers'] as num).toInt(),
+  containersRunning: (json['ContainersRunning'] as num).toInt(),
+  containersPaused: (json['ContainersPaused'] as num).toInt(),
+  containersStopped: (json['ContainersStopped'] as num).toInt(),
+  images: (json['Images'] as num).toInt(),
+  driver: json['Driver'] as String,
+  nCPU: (json['NCPU'] as num).toInt(),
+  memTotal: (json['MemTotal'] as num).toInt(),
+  name: json['Name'] as String,
+  serverVersion: json['ServerVersion'] as String,
 );
 
 Map<String, dynamic> _$DockerInfoToJson(_DockerInfo instance) =>
     <String, dynamic>{
-      'id': instance.id,
-      'containers': instance.containers,
-      'containersRunning': instance.containersRunning,
-      'containersPaused': instance.containersPaused,
-      'containersStopped': instance.containersStopped,
-      'images': instance.images,
-      'driver': instance.driver,
-      'ncpu': instance.ncpu,
-      'memTotal': instance.memTotal,
-      'name': instance.name,
-      'serverVersion': instance.serverVersion,
+      'ID': instance.id,
+      'Containers': instance.containers,
+      'ContainersRunning': instance.containersRunning,
+      'ContainersPaused': instance.containersPaused,
+      'ContainersStopped': instance.containersStopped,
+      'Images': instance.images,
+      'Driver': instance.driver,
+      'NCPU': instance.nCPU,
+      'MemTotal': instance.memTotal,
+      'Name': instance.name,
+      'ServerVersion': instance.serverVersion,
     };
 
 _DockerVersionInfo _$DockerVersionInfoFromJson(Map<String, dynamic> json) =>
     _DockerVersionInfo(
-      version: json['version'] as String,
-      apiVersion: json['apiVersion'] as String,
-      minApiVersion: json['minApiVersion'] as String,
-      gitCommit: json['gitCommit'] as String,
-      goVersion: json['goVersion'] as String,
-      os: json['os'] as String,
-      arch: json['arch'] as String,
-      kernelVersion: json['kernelVersion'] as String,
-      buildTime: json['buildTime'] as String,
+      version: json['Version'] as String,
+      apiVersion: json['ApiVersion'] as String,
+      minAPIVersion: json['MinAPIVersion'] as String,
+      gitCommit: json['GitCommit'] as String,
+      goVersion: json['GoVersion'] as String,
+      os: json['Os'] as String,
+      arch: json['Arch'] as String,
+      kernelVersion: json['KernelVersion'] as String,
+      buildTime: json['BuildTime'] as String,
     );
 
 Map<String, dynamic> _$DockerVersionInfoToJson(_DockerVersionInfo instance) =>
     <String, dynamic>{
-      'version': instance.version,
-      'apiVersion': instance.apiVersion,
-      'minApiVersion': instance.minApiVersion,
-      'gitCommit': instance.gitCommit,
-      'goVersion': instance.goVersion,
-      'os': instance.os,
-      'arch': instance.arch,
-      'kernelVersion': instance.kernelVersion,
-      'buildTime': instance.buildTime,
+      'Version': instance.version,
+      'ApiVersion': instance.apiVersion,
+      'MinAPIVersion': instance.minAPIVersion,
+      'GitCommit': instance.gitCommit,
+      'GoVersion': instance.goVersion,
+      'Os': instance.os,
+      'Arch': instance.arch,
+      'KernelVersion': instance.kernelVersion,
+      'BuildTime': instance.buildTime,
     };

--- a/lib/data/services/api/models/user/user_api_model.dart
+++ b/lib/data/services/api/models/user/user_api_model.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user_api_model.freezed.dart';
+part 'user_api_model.g.dart';
+
+@freezed
+abstract class UserApiModel with _$UserApiModel {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
+  const factory UserApiModel({
+    required int id,
+    required String username,
+    required int role,
+    required tokenIssuedAt,
+  }) = _UserApiModel;
+  factory UserApiModel.fromJson(Map<String, dynamic> json) =>
+      _$UserApiModelFromJson(json);
+}

--- a/lib/data/services/api/models/user/user_api_model.freezed.dart
+++ b/lib/data/services/api/models/user/user_api_model.freezed.dart
@@ -1,0 +1,286 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_api_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$UserApiModel {
+
+ int get id; String get username; int get role; dynamic get tokenIssuedAt;
+/// Create a copy of UserApiModel
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UserApiModelCopyWith<UserApiModel> get copyWith => _$UserApiModelCopyWithImpl<UserApiModel>(this as UserApiModel, _$identity);
+
+  /// Serializes this UserApiModel to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserApiModel&&(identical(other.id, id) || other.id == id)&&(identical(other.username, username) || other.username == username)&&(identical(other.role, role) || other.role == role)&&const DeepCollectionEquality().equals(other.tokenIssuedAt, tokenIssuedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,username,role,const DeepCollectionEquality().hash(tokenIssuedAt));
+
+@override
+String toString() {
+  return 'UserApiModel(id: $id, username: $username, role: $role, tokenIssuedAt: $tokenIssuedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $UserApiModelCopyWith<$Res>  {
+  factory $UserApiModelCopyWith(UserApiModel value, $Res Function(UserApiModel) _then) = _$UserApiModelCopyWithImpl;
+@useResult
+$Res call({
+ int id, String username, int role, dynamic tokenIssuedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$UserApiModelCopyWithImpl<$Res>
+    implements $UserApiModelCopyWith<$Res> {
+  _$UserApiModelCopyWithImpl(this._self, this._then);
+
+  final UserApiModel _self;
+  final $Res Function(UserApiModel) _then;
+
+/// Create a copy of UserApiModel
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? username = null,Object? role = null,Object? tokenIssuedAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,role: null == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
+as int,tokenIssuedAt: freezed == tokenIssuedAt ? _self.tokenIssuedAt : tokenIssuedAt // ignore: cast_nullable_to_non_nullable
+as dynamic,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [UserApiModel].
+extension UserApiModelPatterns on UserApiModel {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UserApiModel value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UserApiModel() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UserApiModel value)  $default,){
+final _that = this;
+switch (_that) {
+case _UserApiModel():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UserApiModel value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UserApiModel() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String username,  int role,  dynamic tokenIssuedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UserApiModel() when $default != null:
+return $default(_that.id,_that.username,_that.role,_that.tokenIssuedAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String username,  int role,  dynamic tokenIssuedAt)  $default,) {final _that = this;
+switch (_that) {
+case _UserApiModel():
+return $default(_that.id,_that.username,_that.role,_that.tokenIssuedAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String username,  int role,  dynamic tokenIssuedAt)?  $default,) {final _that = this;
+switch (_that) {
+case _UserApiModel() when $default != null:
+return $default(_that.id,_that.username,_that.role,_that.tokenIssuedAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.pascal)
+class _UserApiModel implements UserApiModel {
+  const _UserApiModel({required this.id, required this.username, required this.role, required this.tokenIssuedAt});
+  factory _UserApiModel.fromJson(Map<String, dynamic> json) => _$UserApiModelFromJson(json);
+
+@override final  int id;
+@override final  String username;
+@override final  int role;
+@override final  dynamic tokenIssuedAt;
+
+/// Create a copy of UserApiModel
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UserApiModelCopyWith<_UserApiModel> get copyWith => __$UserApiModelCopyWithImpl<_UserApiModel>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$UserApiModelToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserApiModel&&(identical(other.id, id) || other.id == id)&&(identical(other.username, username) || other.username == username)&&(identical(other.role, role) || other.role == role)&&const DeepCollectionEquality().equals(other.tokenIssuedAt, tokenIssuedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,username,role,const DeepCollectionEquality().hash(tokenIssuedAt));
+
+@override
+String toString() {
+  return 'UserApiModel(id: $id, username: $username, role: $role, tokenIssuedAt: $tokenIssuedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UserApiModelCopyWith<$Res> implements $UserApiModelCopyWith<$Res> {
+  factory _$UserApiModelCopyWith(_UserApiModel value, $Res Function(_UserApiModel) _then) = __$UserApiModelCopyWithImpl;
+@override @useResult
+$Res call({
+ int id, String username, int role, dynamic tokenIssuedAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$UserApiModelCopyWithImpl<$Res>
+    implements _$UserApiModelCopyWith<$Res> {
+  __$UserApiModelCopyWithImpl(this._self, this._then);
+
+  final _UserApiModel _self;
+  final $Res Function(_UserApiModel) _then;
+
+/// Create a copy of UserApiModel
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? username = null,Object? role = null,Object? tokenIssuedAt = freezed,}) {
+  return _then(_UserApiModel(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,role: null == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
+as int,tokenIssuedAt: freezed == tokenIssuedAt ? _self.tokenIssuedAt : tokenIssuedAt // ignore: cast_nullable_to_non_nullable
+as dynamic,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/data/services/api/models/user/user_api_model.g.dart
+++ b/lib/data/services/api/models/user/user_api_model.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_api_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_UserApiModel _$UserApiModelFromJson(Map<String, dynamic> json) =>
+    _UserApiModel(
+      id: (json['Id'] as num).toInt(),
+      username: json['Username'] as String,
+      role: (json['Role'] as num).toInt(),
+      tokenIssuedAt: json['TokenIssuedAt'],
+    );
+
+Map<String, dynamic> _$UserApiModelToJson(_UserApiModel instance) =>
+    <String, dynamic>{
+      'Id': instance.id,
+      'Username': instance.username,
+      'Role': instance.role,
+      'TokenIssuedAt': instance.tokenIssuedAt,
+    };

--- a/lib/domain/models/environment/environment_summary.dart
+++ b/lib/domain/models/environment/environment_summary.dart
@@ -1,0 +1,34 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+
+part 'environment_summary.freezed.dart';
+part 'environment_summary.g.dart';
+
+
+@freezed
+abstract class EnvironmentSummary with _$EnvironmentSummary {
+  const factory EnvironmentSummary({
+    required int id,
+    required String name,
+    required int type,
+    required String url,
+    required int status,
+    required int time,
+    required String dockerVersion,
+    required bool swarm,
+    required int totalCpu,
+    required int totalMemory,
+    required int containerCount,
+    required int runningContainerCount,
+    required int stoppedContainerCount,
+    required int healthyContainerCount,
+    required int unhealthyContainerCount,
+    required int volumeCount,
+    required int imageCount,
+    required int serviceCount,
+    required int stackCount,
+  }) = _EnvironmentSummary;
+
+  factory EnvironmentSummary.fromJson(Map<String, dynamic> json) =>
+      _$EnvironmentSummaryFromJson(json);
+}

--- a/lib/domain/models/environment/environment_summary.freezed.dart
+++ b/lib/domain/models/environment/environment_summary.freezed.dart
@@ -1,0 +1,331 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'environment_summary.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$EnvironmentSummary {
+
+ int get id; String get name; int get type; String get url; int get status; int get time; String get dockerVersion; bool get swarm; int get totalCpu; int get totalMemory; int get containerCount; int get runningContainerCount; int get stoppedContainerCount; int get healthyContainerCount; int get unhealthyContainerCount; int get volumeCount; int get imageCount; int get serviceCount; int get stackCount;
+/// Create a copy of EnvironmentSummary
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EnvironmentSummaryCopyWith<EnvironmentSummary> get copyWith => _$EnvironmentSummaryCopyWithImpl<EnvironmentSummary>(this as EnvironmentSummary, _$identity);
+
+  /// Serializes this EnvironmentSummary to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EnvironmentSummary&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.url, url) || other.url == url)&&(identical(other.status, status) || other.status == status)&&(identical(other.time, time) || other.time == time)&&(identical(other.dockerVersion, dockerVersion) || other.dockerVersion == dockerVersion)&&(identical(other.swarm, swarm) || other.swarm == swarm)&&(identical(other.totalCpu, totalCpu) || other.totalCpu == totalCpu)&&(identical(other.totalMemory, totalMemory) || other.totalMemory == totalMemory)&&(identical(other.containerCount, containerCount) || other.containerCount == containerCount)&&(identical(other.runningContainerCount, runningContainerCount) || other.runningContainerCount == runningContainerCount)&&(identical(other.stoppedContainerCount, stoppedContainerCount) || other.stoppedContainerCount == stoppedContainerCount)&&(identical(other.healthyContainerCount, healthyContainerCount) || other.healthyContainerCount == healthyContainerCount)&&(identical(other.unhealthyContainerCount, unhealthyContainerCount) || other.unhealthyContainerCount == unhealthyContainerCount)&&(identical(other.volumeCount, volumeCount) || other.volumeCount == volumeCount)&&(identical(other.imageCount, imageCount) || other.imageCount == imageCount)&&(identical(other.serviceCount, serviceCount) || other.serviceCount == serviceCount)&&(identical(other.stackCount, stackCount) || other.stackCount == stackCount));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hashAll([runtimeType,id,name,type,url,status,time,dockerVersion,swarm,totalCpu,totalMemory,containerCount,runningContainerCount,stoppedContainerCount,healthyContainerCount,unhealthyContainerCount,volumeCount,imageCount,serviceCount,stackCount]);
+
+@override
+String toString() {
+  return 'EnvironmentSummary(id: $id, name: $name, type: $type, url: $url, status: $status, time: $time, dockerVersion: $dockerVersion, swarm: $swarm, totalCpu: $totalCpu, totalMemory: $totalMemory, containerCount: $containerCount, runningContainerCount: $runningContainerCount, stoppedContainerCount: $stoppedContainerCount, healthyContainerCount: $healthyContainerCount, unhealthyContainerCount: $unhealthyContainerCount, volumeCount: $volumeCount, imageCount: $imageCount, serviceCount: $serviceCount, stackCount: $stackCount)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $EnvironmentSummaryCopyWith<$Res>  {
+  factory $EnvironmentSummaryCopyWith(EnvironmentSummary value, $Res Function(EnvironmentSummary) _then) = _$EnvironmentSummaryCopyWithImpl;
+@useResult
+$Res call({
+ int id, String name, int type, String url, int status, int time, String dockerVersion, bool swarm, int totalCpu, int totalMemory, int containerCount, int runningContainerCount, int stoppedContainerCount, int healthyContainerCount, int unhealthyContainerCount, int volumeCount, int imageCount, int serviceCount, int stackCount
+});
+
+
+
+
+}
+/// @nodoc
+class _$EnvironmentSummaryCopyWithImpl<$Res>
+    implements $EnvironmentSummaryCopyWith<$Res> {
+  _$EnvironmentSummaryCopyWithImpl(this._self, this._then);
+
+  final EnvironmentSummary _self;
+  final $Res Function(EnvironmentSummary) _then;
+
+/// Create a copy of EnvironmentSummary
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? url = null,Object? status = null,Object? time = null,Object? dockerVersion = null,Object? swarm = null,Object? totalCpu = null,Object? totalMemory = null,Object? containerCount = null,Object? runningContainerCount = null,Object? stoppedContainerCount = null,Object? healthyContainerCount = null,Object? unhealthyContainerCount = null,Object? volumeCount = null,Object? imageCount = null,Object? serviceCount = null,Object? stackCount = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as int,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as int,time: null == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
+as int,dockerVersion: null == dockerVersion ? _self.dockerVersion : dockerVersion // ignore: cast_nullable_to_non_nullable
+as String,swarm: null == swarm ? _self.swarm : swarm // ignore: cast_nullable_to_non_nullable
+as bool,totalCpu: null == totalCpu ? _self.totalCpu : totalCpu // ignore: cast_nullable_to_non_nullable
+as int,totalMemory: null == totalMemory ? _self.totalMemory : totalMemory // ignore: cast_nullable_to_non_nullable
+as int,containerCount: null == containerCount ? _self.containerCount : containerCount // ignore: cast_nullable_to_non_nullable
+as int,runningContainerCount: null == runningContainerCount ? _self.runningContainerCount : runningContainerCount // ignore: cast_nullable_to_non_nullable
+as int,stoppedContainerCount: null == stoppedContainerCount ? _self.stoppedContainerCount : stoppedContainerCount // ignore: cast_nullable_to_non_nullable
+as int,healthyContainerCount: null == healthyContainerCount ? _self.healthyContainerCount : healthyContainerCount // ignore: cast_nullable_to_non_nullable
+as int,unhealthyContainerCount: null == unhealthyContainerCount ? _self.unhealthyContainerCount : unhealthyContainerCount // ignore: cast_nullable_to_non_nullable
+as int,volumeCount: null == volumeCount ? _self.volumeCount : volumeCount // ignore: cast_nullable_to_non_nullable
+as int,imageCount: null == imageCount ? _self.imageCount : imageCount // ignore: cast_nullable_to_non_nullable
+as int,serviceCount: null == serviceCount ? _self.serviceCount : serviceCount // ignore: cast_nullable_to_non_nullable
+as int,stackCount: null == stackCount ? _self.stackCount : stackCount // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [EnvironmentSummary].
+extension EnvironmentSummaryPatterns on EnvironmentSummary {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EnvironmentSummary value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EnvironmentSummary() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EnvironmentSummary value)  $default,){
+final _that = this;
+switch (_that) {
+case _EnvironmentSummary():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EnvironmentSummary value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EnvironmentSummary() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String name,  int type,  String url,  int status,  int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EnvironmentSummary() when $default != null:
+return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String name,  int type,  String url,  int status,  int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount)  $default,) {final _that = this;
+switch (_that) {
+case _EnvironmentSummary():
+return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String name,  int type,  String url,  int status,  int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount)?  $default,) {final _that = this;
+switch (_that) {
+case _EnvironmentSummary() when $default != null:
+return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _EnvironmentSummary implements EnvironmentSummary {
+  const _EnvironmentSummary({required this.id, required this.name, required this.type, required this.url, required this.status, required this.time, required this.dockerVersion, required this.swarm, required this.totalCpu, required this.totalMemory, required this.containerCount, required this.runningContainerCount, required this.stoppedContainerCount, required this.healthyContainerCount, required this.unhealthyContainerCount, required this.volumeCount, required this.imageCount, required this.serviceCount, required this.stackCount});
+  factory _EnvironmentSummary.fromJson(Map<String, dynamic> json) => _$EnvironmentSummaryFromJson(json);
+
+@override final  int id;
+@override final  String name;
+@override final  int type;
+@override final  String url;
+@override final  int status;
+@override final  int time;
+@override final  String dockerVersion;
+@override final  bool swarm;
+@override final  int totalCpu;
+@override final  int totalMemory;
+@override final  int containerCount;
+@override final  int runningContainerCount;
+@override final  int stoppedContainerCount;
+@override final  int healthyContainerCount;
+@override final  int unhealthyContainerCount;
+@override final  int volumeCount;
+@override final  int imageCount;
+@override final  int serviceCount;
+@override final  int stackCount;
+
+/// Create a copy of EnvironmentSummary
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EnvironmentSummaryCopyWith<_EnvironmentSummary> get copyWith => __$EnvironmentSummaryCopyWithImpl<_EnvironmentSummary>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$EnvironmentSummaryToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EnvironmentSummary&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.url, url) || other.url == url)&&(identical(other.status, status) || other.status == status)&&(identical(other.time, time) || other.time == time)&&(identical(other.dockerVersion, dockerVersion) || other.dockerVersion == dockerVersion)&&(identical(other.swarm, swarm) || other.swarm == swarm)&&(identical(other.totalCpu, totalCpu) || other.totalCpu == totalCpu)&&(identical(other.totalMemory, totalMemory) || other.totalMemory == totalMemory)&&(identical(other.containerCount, containerCount) || other.containerCount == containerCount)&&(identical(other.runningContainerCount, runningContainerCount) || other.runningContainerCount == runningContainerCount)&&(identical(other.stoppedContainerCount, stoppedContainerCount) || other.stoppedContainerCount == stoppedContainerCount)&&(identical(other.healthyContainerCount, healthyContainerCount) || other.healthyContainerCount == healthyContainerCount)&&(identical(other.unhealthyContainerCount, unhealthyContainerCount) || other.unhealthyContainerCount == unhealthyContainerCount)&&(identical(other.volumeCount, volumeCount) || other.volumeCount == volumeCount)&&(identical(other.imageCount, imageCount) || other.imageCount == imageCount)&&(identical(other.serviceCount, serviceCount) || other.serviceCount == serviceCount)&&(identical(other.stackCount, stackCount) || other.stackCount == stackCount));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hashAll([runtimeType,id,name,type,url,status,time,dockerVersion,swarm,totalCpu,totalMemory,containerCount,runningContainerCount,stoppedContainerCount,healthyContainerCount,unhealthyContainerCount,volumeCount,imageCount,serviceCount,stackCount]);
+
+@override
+String toString() {
+  return 'EnvironmentSummary(id: $id, name: $name, type: $type, url: $url, status: $status, time: $time, dockerVersion: $dockerVersion, swarm: $swarm, totalCpu: $totalCpu, totalMemory: $totalMemory, containerCount: $containerCount, runningContainerCount: $runningContainerCount, stoppedContainerCount: $stoppedContainerCount, healthyContainerCount: $healthyContainerCount, unhealthyContainerCount: $unhealthyContainerCount, volumeCount: $volumeCount, imageCount: $imageCount, serviceCount: $serviceCount, stackCount: $stackCount)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$EnvironmentSummaryCopyWith<$Res> implements $EnvironmentSummaryCopyWith<$Res> {
+  factory _$EnvironmentSummaryCopyWith(_EnvironmentSummary value, $Res Function(_EnvironmentSummary) _then) = __$EnvironmentSummaryCopyWithImpl;
+@override @useResult
+$Res call({
+ int id, String name, int type, String url, int status, int time, String dockerVersion, bool swarm, int totalCpu, int totalMemory, int containerCount, int runningContainerCount, int stoppedContainerCount, int healthyContainerCount, int unhealthyContainerCount, int volumeCount, int imageCount, int serviceCount, int stackCount
+});
+
+
+
+
+}
+/// @nodoc
+class __$EnvironmentSummaryCopyWithImpl<$Res>
+    implements _$EnvironmentSummaryCopyWith<$Res> {
+  __$EnvironmentSummaryCopyWithImpl(this._self, this._then);
+
+  final _EnvironmentSummary _self;
+  final $Res Function(_EnvironmentSummary) _then;
+
+/// Create a copy of EnvironmentSummary
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? url = null,Object? status = null,Object? time = null,Object? dockerVersion = null,Object? swarm = null,Object? totalCpu = null,Object? totalMemory = null,Object? containerCount = null,Object? runningContainerCount = null,Object? stoppedContainerCount = null,Object? healthyContainerCount = null,Object? unhealthyContainerCount = null,Object? volumeCount = null,Object? imageCount = null,Object? serviceCount = null,Object? stackCount = null,}) {
+  return _then(_EnvironmentSummary(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as int,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as int,time: null == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
+as int,dockerVersion: null == dockerVersion ? _self.dockerVersion : dockerVersion // ignore: cast_nullable_to_non_nullable
+as String,swarm: null == swarm ? _self.swarm : swarm // ignore: cast_nullable_to_non_nullable
+as bool,totalCpu: null == totalCpu ? _self.totalCpu : totalCpu // ignore: cast_nullable_to_non_nullable
+as int,totalMemory: null == totalMemory ? _self.totalMemory : totalMemory // ignore: cast_nullable_to_non_nullable
+as int,containerCount: null == containerCount ? _self.containerCount : containerCount // ignore: cast_nullable_to_non_nullable
+as int,runningContainerCount: null == runningContainerCount ? _self.runningContainerCount : runningContainerCount // ignore: cast_nullable_to_non_nullable
+as int,stoppedContainerCount: null == stoppedContainerCount ? _self.stoppedContainerCount : stoppedContainerCount // ignore: cast_nullable_to_non_nullable
+as int,healthyContainerCount: null == healthyContainerCount ? _self.healthyContainerCount : healthyContainerCount // ignore: cast_nullable_to_non_nullable
+as int,unhealthyContainerCount: null == unhealthyContainerCount ? _self.unhealthyContainerCount : unhealthyContainerCount // ignore: cast_nullable_to_non_nullable
+as int,volumeCount: null == volumeCount ? _self.volumeCount : volumeCount // ignore: cast_nullable_to_non_nullable
+as int,imageCount: null == imageCount ? _self.imageCount : imageCount // ignore: cast_nullable_to_non_nullable
+as int,serviceCount: null == serviceCount ? _self.serviceCount : serviceCount // ignore: cast_nullable_to_non_nullable
+as int,stackCount: null == stackCount ? _self.stackCount : stackCount // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/domain/models/environment/environment_summary.g.dart
+++ b/lib/domain/models/environment/environment_summary.g.dart
@@ -1,0 +1,53 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'environment_summary.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_EnvironmentSummary _$EnvironmentSummaryFromJson(Map<String, dynamic> json) =>
+    _EnvironmentSummary(
+      id: (json['id'] as num).toInt(),
+      name: json['name'] as String,
+      type: (json['type'] as num).toInt(),
+      url: json['url'] as String,
+      status: (json['status'] as num).toInt(),
+      time: (json['time'] as num).toInt(),
+      dockerVersion: json['dockerVersion'] as String,
+      swarm: json['swarm'] as bool,
+      totalCpu: (json['totalCpu'] as num).toInt(),
+      totalMemory: (json['totalMemory'] as num).toInt(),
+      containerCount: (json['containerCount'] as num).toInt(),
+      runningContainerCount: (json['runningContainerCount'] as num).toInt(),
+      stoppedContainerCount: (json['stoppedContainerCount'] as num).toInt(),
+      healthyContainerCount: (json['healthyContainerCount'] as num).toInt(),
+      unhealthyContainerCount: (json['unhealthyContainerCount'] as num).toInt(),
+      volumeCount: (json['volumeCount'] as num).toInt(),
+      imageCount: (json['imageCount'] as num).toInt(),
+      serviceCount: (json['serviceCount'] as num).toInt(),
+      stackCount: (json['stackCount'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$EnvironmentSummaryToJson(_EnvironmentSummary instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'type': instance.type,
+      'url': instance.url,
+      'status': instance.status,
+      'time': instance.time,
+      'dockerVersion': instance.dockerVersion,
+      'swarm': instance.swarm,
+      'totalCpu': instance.totalCpu,
+      'totalMemory': instance.totalMemory,
+      'containerCount': instance.containerCount,
+      'runningContainerCount': instance.runningContainerCount,
+      'stoppedContainerCount': instance.stoppedContainerCount,
+      'healthyContainerCount': instance.healthyContainerCount,
+      'unhealthyContainerCount': instance.unhealthyContainerCount,
+      'volumeCount': instance.volumeCount,
+      'imageCount': instance.imageCount,
+      'serviceCount': instance.serviceCount,
+      'stackCount': instance.stackCount,
+    };

--- a/lib/routing/router.dart
+++ b/lib/routing/router.dart
@@ -1,11 +1,13 @@
 import 'package:container_monitoring/ui/auth/login/view_models/login_viewmodel.dart';
+import 'package:container_monitoring/ui/home/view_models/home_viewmodel.dart';
+import 'package:container_monitoring/ui/main_home/widgets/main_home_screen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 
 import '../data/repositories/auth/auth_repository.dart';
 import '../ui/auth/login/widgets/login_screen.dart';
 import 'routes.dart';
-
 
 GoRouter router(AuthRepository authRepository) => GoRouter(
   initialLocation: Routes.login,
@@ -14,34 +16,42 @@ GoRouter router(AuthRepository authRepository) => GoRouter(
   refreshListenable: authRepository,
   routes: [
     GoRoute(
+      name: 'login',
       path: Routes.login,
       builder: (context, state) {
         return LoginScreen(
-          viewModel: LoginViewModel(authRepository: authRepository)
+          viewModel: LoginViewModel(authRepository: context.read()),
         );
-      }
+      },
     ),
-  ]
+    GoRoute(
+      name: 'home',
+      path: Routes.home,
+      builder: (context, state) {
+        final homeViewModel = HomeViewModel(
+          environmentRepository: context.read(),
+        );
+        return MainHomeScreen(homeViewModel: homeViewModel);
+      },
+    ),
+  ],
 );
 
 // From https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/redirection.dart
 Future<String?> _redirect(BuildContext context, GoRouterState state) async {
-  // Temporarily skip authentication for testing home screen
-  return null;
-  
   // if the user is not logged in, they need to login
-  // final loggedIn = await context.read<AuthRepository>().isAuthenticated;
-  // final loggingIn = state.matchedLocation == Routes.login;
-  // if (!loggedIn) {
-  //   return Routes.login;
-  // }
+  final loggedIn = await context.read<AuthRepository>().isAuthenticated;
+  final loggingIn = state.matchedLocation == Routes.login;
+  if (!loggedIn) {
+    return Routes.login;
+  }
 
   // if the user is logged in but still on the login page, send them to
   // the home page
-  // if (loggingIn) {
-  //   return Routes.home;
-  // }
+  if (loggingIn) {
+    return Routes.home;
+  }
 
   // no need to redirect at all
-  // return null;
+  return null;
 }

--- a/lib/ui/home/view_models/home_viewmodel.dart
+++ b/lib/ui/home/view_models/home_viewmodel.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+
+import 'package:container_monitoring/domain/models/environment/environment_summary.dart';
+import 'package:container_monitoring/data/repositories/environment/environment.dart';
+import 'package:container_monitoring/utils/command.dart';
+import 'package:container_monitoring/utils/result.dart';
+
+class HomeViewModel extends ChangeNotifier {
+  HomeViewModel({required EnvironmentRepository environmentRepository})
+    : _environmentRepository = environmentRepository {
+      load = Command0(_load)..execute();
+    }
+
+  final EnvironmentRepository _environmentRepository;
+  final _log = Logger('HomeViewModel');
+  List<EnvironmentSummary> _environments = [];
+  
+  late Command0 load;
+
+  List<EnvironmentSummary> get environments => _environments;
+
+
+  Future<Result> _load() async {
+    try {
+      final result = await _environmentRepository.listEnvironments();
+      switch (result) {
+        case Ok<List<EnvironmentSummary>>():
+          _environments = result.value;
+          _log.fine('Loaded environments');
+        case Error<List<EnvironmentSummary>>():
+          _log.warning('Failed to load environments', result.error);
+          return result;
+      }
+      return result;
+    } finally {
+      notifyListeners();
+    }
+  }
+}

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -1,17 +1,179 @@
+import 'package:container_monitoring/domain/models/environment/environment_summary.dart';
+import 'package:container_monitoring/ui/home/view_models/home_viewmodel.dart';
 import 'package:flutter/material.dart';
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key, required this.viewModel});
 
+  final HomeViewModel viewModel;
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Home Screen'),
+      body: Padding(
+        padding: const EdgeInsets.all(6.0),
+        child: ListenableBuilder(
+          listenable: widget.viewModel,
+          builder: (context, child) {
+            return ListView.separated(
+              itemCount: widget.viewModel.environments.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 6),
+              itemBuilder: (context, index) {
+                final e = widget.viewModel.environments[index];
+                return EnvironmentCard(environment: e);
+              },
+            );
+          },
+        ),
       ),
-      body: const Center(
-        child: Text('Welcome to the Home Screen!'),
+    );
+  }
+}
+
+class EnvironmentCard extends StatelessWidget {
+  final EnvironmentSummary environment;
+
+  const EnvironmentCard({super.key, required this.environment});
+
+  @override
+  Widget build(BuildContext context) {
+    // A richer card layout that resembles the screenshot: icon, name, quick stats and actions
+    final isRunning = environment.status == 1;
+
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Icon(Icons.laptop_outlined, size: 28),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            environment.name,
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          Chip(
+                            label: Text(isRunning ? 'Up' : 'Down'),
+                            avatar: Icon(
+                              isRunning ? Icons.check_circle : Icons.error,
+                              color: isRunning ? Colors.green : Colors.red,
+                              size: 18,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        'Standalone ${environment.dockerVersion} ${environment.url}',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              children: [
+                _StatItem(
+                  icon: Icons.layers,
+                  label: '${environment.stackCount} stacks',
+                ),
+                _StatItem(
+                  icon: Icons.storage,
+                  label: '${environment.containerCount} containers',
+                ),
+                _StatItem(
+                  icon: Icons.folder,
+                  label: '${environment.volumeCount} volumes',
+                ),
+                _StatItem(
+                  icon: Icons.list,
+                  label: '${environment.imageCount} images',
+                ),
+                _StatItem(
+                  icon: Icons.memory,
+                  label: '${environment.totalCpu} CPU',
+                ),
+                _StatItem(
+                  icon: Icons.sd_storage,
+                  label:
+                      '${(environment.totalMemory / 1000 / 1000 / 1000).toStringAsFixed(1)} GB RAM',
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 8,
+                  ),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.circle, color: Colors.green, size: 10),
+                      const SizedBox(width: 6),
+                      const Text('Connected', style: TextStyle(fontSize: 13)),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
+    );
+  }
+}
+
+class _StatItem extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _StatItem({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: Colors.grey.shade700),
+        const SizedBox(width: 6),
+        Text(label),
+      ],
     );
   }
 }

--- a/lib/ui/main_home/widgets/bottom_navigation.dart
+++ b/lib/ui/main_home/widgets/bottom_navigation.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+
+class MainBottomNavigation extends StatelessWidget {
+  final int currentIndex;
+  final ValueChanged<int> onTap;
+
+  const MainBottomNavigation({
+    super.key,
+    required this.currentIndex,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationBar(
+      selectedIndex: currentIndex,
+      onDestinationSelected: onTap,
+      destinations: const <Widget>[
+        NavigationDestination(
+          selectedIcon: Icon(Icons.home),
+          icon: Icon(Icons.home_outlined),
+          label: 'Home',
+        ),
+        NavigationDestination(
+          selectedIcon: Icon(Icons.person),
+          icon: Badge(child: Icon(Icons.person_outlined)),
+          label: 'Profile',
+        ),
+      ],
+    );
+  }
+}
+
+class NavigationExample extends StatefulWidget {
+  const NavigationExample({super.key});
+
+  @override
+  State<NavigationExample> createState() => _NavigationExampleState();
+}
+
+class _NavigationExampleState extends State<NavigationExample> {
+  int currentPageIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Scaffold(
+      bottomNavigationBar: NavigationBar(
+        onDestinationSelected: (int index) {
+          setState(() {
+            currentPageIndex = index;
+          });
+        },
+        indicatorColor: Colors.amber,
+        selectedIndex: currentPageIndex,
+        destinations: const <Widget>[
+          NavigationDestination(
+            selectedIcon: Icon(Icons.home),
+            icon: Icon(Icons.home_outlined),
+            label: 'Home',
+          ),
+          NavigationDestination(
+            icon: Badge(child: Icon(Icons.notifications_sharp)),
+            label: 'Notifications',
+          ),
+          NavigationDestination(
+            icon: Badge(label: Text('2'), child: Icon(Icons.messenger_sharp)),
+            label: 'Messages',
+          ),
+        ],
+      ),
+      body: <Widget>[
+        /// Home page
+        Card(
+          shadowColor: Colors.transparent,
+          margin: const EdgeInsets.all(8.0),
+          child: SizedBox.expand(
+            child: Center(
+              child: Text('Home page', style: theme.textTheme.titleLarge),
+            ),
+          ),
+        ),
+
+        /// Notifications page
+        const Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Column(
+            children: <Widget>[
+              Card(
+                child: ListTile(
+                  leading: Icon(Icons.notifications_sharp),
+                  title: Text('Notification 1'),
+                  subtitle: Text('This is a notification'),
+                ),
+              ),
+              Card(
+                child: ListTile(
+                  leading: Icon(Icons.notifications_sharp),
+                  title: Text('Notification 2'),
+                  subtitle: Text('This is a notification'),
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        /// Messages page
+        ListView.builder(
+          reverse: true,
+          itemCount: 2,
+          itemBuilder: (BuildContext context, int index) {
+            if (index == 0) {
+              return Align(
+                alignment: Alignment.centerRight,
+                child: Container(
+                  margin: const EdgeInsets.all(8.0),
+                  padding: const EdgeInsets.all(8.0),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primary,
+                    borderRadius: BorderRadius.circular(8.0),
+                  ),
+                  child: Text(
+                    'Hello',
+                    style: theme.textTheme.bodyLarge!.copyWith(
+                      color: theme.colorScheme.onPrimary,
+                    ),
+                  ),
+                ),
+              );
+            }
+            return Align(
+              alignment: Alignment.centerLeft,
+              child: Container(
+                margin: const EdgeInsets.all(8.0),
+                padding: const EdgeInsets.all(8.0),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primary,
+                  borderRadius: BorderRadius.circular(8.0),
+                ),
+                child: Text(
+                  'Hi!',
+                  style: theme.textTheme.bodyLarge!.copyWith(
+                    color: theme.colorScheme.onPrimary,
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ][currentPageIndex],
+    );
+  }
+}

--- a/lib/ui/main_home/widgets/main_home_screen.dart
+++ b/lib/ui/main_home/widgets/main_home_screen.dart
@@ -1,0 +1,42 @@
+import 'package:container_monitoring/ui/home/view_models/home_viewmodel.dart';
+import 'package:container_monitoring/ui/home/widgets/home_screen.dart';
+import 'package:flutter/material.dart';
+
+import 'bottom_navigation.dart';
+
+class MainHomeScreen extends StatefulWidget {
+	const MainHomeScreen({super.key, required this.homeViewModel});
+
+  final HomeViewModel homeViewModel;
+
+	@override
+	State<MainHomeScreen> createState() => _MainHomeScreenState();
+}
+
+class _MainHomeScreenState extends State<MainHomeScreen> {
+	int _currentIndex = 0;
+
+	final List<Widget> _pages = [];
+
+	@override
+	void initState() {
+		super.initState();
+		_pages.add(HomeScreen(viewModel: widget.homeViewModel));
+		_pages.add(const Center(child: Text('Profile', style: TextStyle(fontSize: 20))));
+	}
+
+	void _onTap(int index) {
+		setState(() => _currentIndex = index);
+	}
+
+	@override
+	Widget build(BuildContext context) {
+		return Scaffold(
+			body: _pages[_currentIndex],
+			bottomNavigationBar: MainBottomNavigation(
+				currentIndex: _currentIndex,
+				onTap: _onTap,
+			),
+		);
+	}
+}


### PR DESCRIPTION
This pull request introduces support for environment listing and improves authentication handling, including automatic token refresh on unauthorized API responses. The main changes add new repositories and API methods for environments, refactor authentication repositories to support token refresh, and update models for better API compatibility.

**Authentication improvements:**

* Added a `refreshToken` method to the `AuthRepository` interface and implemented it in both `AuthRepositoryRemote` and `AuthRepositoryDev`, enabling automatic JWT refresh when a 401 response is received. [[1]](diffhunk://#diff-0d761570b6bf1271cc4c15e7752e6be7b58dc69e548185ed25082c074e64ac0bR10-R13) [[2]](diffhunk://#diff-c4a9aff4e9911ee8dd053abe8930a05837da9023b7b6956c238f0d63975b5686L6-R14) [[3]](diffhunk://#diff-faf327a831e050110a98cd4e85898e0fe6f526cad403cf11674f9932d34f3450R81-R109)
* Updated `ApiClient` to support an `authRefreshProvider` callback, which is called to attempt token refresh on unauthorized API responses. The client now retries requests after a successful refresh.
* Implemented the `/api/auth/refresh` endpoint in `AuthApiClient` to obtain a new JWT token.

**Environment repository and API support:**

* Added `EnvironmentRepository` and its remote implementation `EnvironmentRemoteRepository`, with a method to list environments using the new API client logic. [[1]](diffhunk://#diff-c7880daa8b823ac386a31a843f6ee52426e16cfe94e0d70b09a392b7e596e156L1-R7) [[2]](diffhunk://#diff-78daba57824a0965e75360a21c94e598c18a939e06aae45c9288304c92950d12R1-R61)
* Registered the new environment repository in the dependency injection setup, making it available to the app. [[1]](diffhunk://#diff-51b73d02b0c8d559c89f955c673d27d225425a281862c9d357be6dd66010ef3dR9-R10) [[2]](diffhunk://#diff-51b73d02b0c8d559c89f955c673d27d225425a281862c9d357be6dd66010ef3dR23-R42)

**Model compatibility and improvements:**

* Updated the `Environment`, `TLSConfig`, `AzureCredentials`, `Snapshot`, `DockerSnapshotRaw`, and `ContainerInfo` models to use PascalCase field renaming and made several fields optional, improving compatibility with backend API responses. [[1]](diffhunk://#diff-5b30045f61d0f75c6dc3951d0575c580f55a83fecec32e521484fa021e33732dR8-R59) [[2]](diffhunk://#diff-5b30045f61d0f75c6dc3951d0575c580f55a83fecec32e521484fa021e33732dL68-R79) [[3]](diffhunk://#diff-5b30045f61d0f75c6dc3951d0575c580f55a83fecec32e521484fa021e33732dL82-R100)