### PR TITLE
feat: dashboard screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+.cursor/

--- a/lib/data/repositories/environment/environment.dart
+++ b/lib/data/repositories/environment/environment.dart
@@ -6,4 +6,7 @@ abstract class EnvironmentRepository {
   /// List all environments  
   Future<Result<List<EnvironmentSummary>>> listEnvironments();
 
+  /// Get environment details by ID
+  Future<Result<EnvironmentSummary>> getEnvironment(int id);
+
 }

--- a/lib/data/repositories/environment/environment_remote.dart
+++ b/lib/data/repositories/environment/environment_remote.dart
@@ -50,6 +50,7 @@ class EnvironmentRepositoryRemote extends EnvironmentRepository {
                 imageCount: environmentApi.snapshots[0].imageCount,
                 serviceCount: environmentApi.snapshots[0].serviceCount,
                 stackCount: environmentApi.snapshots[0].stackCount,
+                networkCount: environmentApi.snapshots[0].dockerSnapshotRaw.networks.length,
               ),
             )
             .toList(),
@@ -58,4 +59,49 @@ class EnvironmentRepositoryRemote extends EnvironmentRepository {
       return Result.error(error);
     }
   }
+
+  @override
+  Future<Result<EnvironmentSummary>> getEnvironment(int id) async {
+    // You can implement caching logic here if needed
+    try {
+      final result = await _apiClient.getEnvironment(id);
+      switch (result) {
+        case Error<Environment>():
+          return Result.error(result.error);
+        case Ok<Environment>():
+      }
+      final environmentApi = result.value;
+      return Result.ok(
+        EnvironmentSummary(
+          id: environmentApi.id,
+          name: environmentApi.name,
+          type: environmentApi.type,
+          url: environmentApi.uRL,
+          status: environmentApi.status,
+          time: environmentApi.snapshots[0].time,
+          dockerVersion: environmentApi.snapshots[0].dockerVersion,
+          swarm: environmentApi.snapshots[0].swarm,
+          totalCpu: environmentApi.snapshots[0].totalCPU,
+          totalMemory: environmentApi.snapshots[0].totalMemory,
+          containerCount: environmentApi.snapshots[0].containerCount,
+          runningContainerCount:
+              environmentApi.snapshots[0].runningContainerCount,
+          stoppedContainerCount:
+              environmentApi.snapshots[0].stoppedContainerCount,
+          healthyContainerCount:
+              environmentApi.snapshots[0].healthyContainerCount,
+          unhealthyContainerCount:
+              environmentApi.snapshots[0].unhealthyContainerCount,
+          volumeCount: environmentApi.snapshots[0].volumeCount,
+          imageCount: environmentApi.snapshots[0].imageCount,
+          serviceCount: environmentApi.snapshots[0].serviceCount,
+          stackCount: environmentApi.snapshots[0].stackCount,
+          networkCount: environmentApi.snapshots[0].dockerSnapshotRaw.networks.length,
+        ),
+      );
+    } on Exception catch (error) {
+      return Result.error(error);
+    }
+  }
+    // Implementation for fetching a single environment by ID
 }

--- a/lib/domain/models/environment/environment_summary.dart
+++ b/lib/domain/models/environment/environment_summary.dart
@@ -27,6 +27,7 @@ abstract class EnvironmentSummary with _$EnvironmentSummary {
     required int imageCount,
     required int serviceCount,
     required int stackCount,
+    required int networkCount,
   }) = _EnvironmentSummary;
 
   factory EnvironmentSummary.fromJson(Map<String, dynamic> json) =>

--- a/lib/domain/models/environment/environment_summary.freezed.dart
+++ b/lib/domain/models/environment/environment_summary.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EnvironmentSummary {
 
- int get id; String get name; int get type; String get url; int get status; int get time; String get dockerVersion; bool get swarm; int get totalCpu; int get totalMemory; int get containerCount; int get runningContainerCount; int get stoppedContainerCount; int get healthyContainerCount; int get unhealthyContainerCount; int get volumeCount; int get imageCount; int get serviceCount; int get stackCount;
+ int get id; String get name; int get type; String get url; int get status; int get time; String get dockerVersion; bool get swarm; int get totalCpu; int get totalMemory; int get containerCount; int get runningContainerCount; int get stoppedContainerCount; int get healthyContainerCount; int get unhealthyContainerCount; int get volumeCount; int get imageCount; int get serviceCount; int get stackCount; int get networkCount;
 /// Create a copy of EnvironmentSummary
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $EnvironmentSummaryCopyWith<EnvironmentSummary> get copyWith => _$EnvironmentSum
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EnvironmentSummary&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.url, url) || other.url == url)&&(identical(other.status, status) || other.status == status)&&(identical(other.time, time) || other.time == time)&&(identical(other.dockerVersion, dockerVersion) || other.dockerVersion == dockerVersion)&&(identical(other.swarm, swarm) || other.swarm == swarm)&&(identical(other.totalCpu, totalCpu) || other.totalCpu == totalCpu)&&(identical(other.totalMemory, totalMemory) || other.totalMemory == totalMemory)&&(identical(other.containerCount, containerCount) || other.containerCount == containerCount)&&(identical(other.runningContainerCount, runningContainerCount) || other.runningContainerCount == runningContainerCount)&&(identical(other.stoppedContainerCount, stoppedContainerCount) || other.stoppedContainerCount == stoppedContainerCount)&&(identical(other.healthyContainerCount, healthyContainerCount) || other.healthyContainerCount == healthyContainerCount)&&(identical(other.unhealthyContainerCount, unhealthyContainerCount) || other.unhealthyContainerCount == unhealthyContainerCount)&&(identical(other.volumeCount, volumeCount) || other.volumeCount == volumeCount)&&(identical(other.imageCount, imageCount) || other.imageCount == imageCount)&&(identical(other.serviceCount, serviceCount) || other.serviceCount == serviceCount)&&(identical(other.stackCount, stackCount) || other.stackCount == stackCount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EnvironmentSummary&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.url, url) || other.url == url)&&(identical(other.status, status) || other.status == status)&&(identical(other.time, time) || other.time == time)&&(identical(other.dockerVersion, dockerVersion) || other.dockerVersion == dockerVersion)&&(identical(other.swarm, swarm) || other.swarm == swarm)&&(identical(other.totalCpu, totalCpu) || other.totalCpu == totalCpu)&&(identical(other.totalMemory, totalMemory) || other.totalMemory == totalMemory)&&(identical(other.containerCount, containerCount) || other.containerCount == containerCount)&&(identical(other.runningContainerCount, runningContainerCount) || other.runningContainerCount == runningContainerCount)&&(identical(other.stoppedContainerCount, stoppedContainerCount) || other.stoppedContainerCount == stoppedContainerCount)&&(identical(other.healthyContainerCount, healthyContainerCount) || other.healthyContainerCount == healthyContainerCount)&&(identical(other.unhealthyContainerCount, unhealthyContainerCount) || other.unhealthyContainerCount == unhealthyContainerCount)&&(identical(other.volumeCount, volumeCount) || other.volumeCount == volumeCount)&&(identical(other.imageCount, imageCount) || other.imageCount == imageCount)&&(identical(other.serviceCount, serviceCount) || other.serviceCount == serviceCount)&&(identical(other.stackCount, stackCount) || other.stackCount == stackCount)&&(identical(other.networkCount, networkCount) || other.networkCount == networkCount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,type,url,status,time,dockerVersion,swarm,totalCpu,totalMemory,containerCount,runningContainerCount,stoppedContainerCount,healthyContainerCount,unhealthyContainerCount,volumeCount,imageCount,serviceCount,stackCount]);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,url,status,time,dockerVersion,swarm,totalCpu,totalMemory,containerCount,runningContainerCount,stoppedContainerCount,healthyContainerCount,unhealthyContainerCount,volumeCount,imageCount,serviceCount,stackCount,networkCount]);
 
 @override
 String toString() {
-  return 'EnvironmentSummary(id: $id, name: $name, type: $type, url: $url, status: $status, time: $time, dockerVersion: $dockerVersion, swarm: $swarm, totalCpu: $totalCpu, totalMemory: $totalMemory, containerCount: $containerCount, runningContainerCount: $runningContainerCount, stoppedContainerCount: $stoppedContainerCount, healthyContainerCount: $healthyContainerCount, unhealthyContainerCount: $unhealthyContainerCount, volumeCount: $volumeCount, imageCount: $imageCount, serviceCount: $serviceCount, stackCount: $stackCount)';
+  return 'EnvironmentSummary(id: $id, name: $name, type: $type, url: $url, status: $status, time: $time, dockerVersion: $dockerVersion, swarm: $swarm, totalCpu: $totalCpu, totalMemory: $totalMemory, containerCount: $containerCount, runningContainerCount: $runningContainerCount, stoppedContainerCount: $stoppedContainerCount, healthyContainerCount: $healthyContainerCount, unhealthyContainerCount: $unhealthyContainerCount, volumeCount: $volumeCount, imageCount: $imageCount, serviceCount: $serviceCount, stackCount: $stackCount, networkCount: $networkCount)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $EnvironmentSummaryCopyWith<$Res>  {
   factory $EnvironmentSummaryCopyWith(EnvironmentSummary value, $Res Function(EnvironmentSummary) _then) = _$EnvironmentSummaryCopyWithImpl;
 @useResult
 $Res call({
- int id, String name, int type, String url, int status, int time, String dockerVersion, bool swarm, int totalCpu, int totalMemory, int containerCount, int runningContainerCount, int stoppedContainerCount, int healthyContainerCount, int unhealthyContainerCount, int volumeCount, int imageCount, int serviceCount, int stackCount
+ int id, String name, int type, String url, int status, int time, String dockerVersion, bool swarm, int totalCpu, int totalMemory, int containerCount, int runningContainerCount, int stoppedContainerCount, int healthyContainerCount, int unhealthyContainerCount, int volumeCount, int imageCount, int serviceCount, int stackCount, int networkCount
 });
 
 
@@ -65,7 +65,7 @@ class _$EnvironmentSummaryCopyWithImpl<$Res>
 
 /// Create a copy of EnvironmentSummary
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? url = null,Object? status = null,Object? time = null,Object? dockerVersion = null,Object? swarm = null,Object? totalCpu = null,Object? totalMemory = null,Object? containerCount = null,Object? runningContainerCount = null,Object? stoppedContainerCount = null,Object? healthyContainerCount = null,Object? unhealthyContainerCount = null,Object? volumeCount = null,Object? imageCount = null,Object? serviceCount = null,Object? stackCount = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? url = null,Object? status = null,Object? time = null,Object? dockerVersion = null,Object? swarm = null,Object? totalCpu = null,Object? totalMemory = null,Object? containerCount = null,Object? runningContainerCount = null,Object? stoppedContainerCount = null,Object? healthyContainerCount = null,Object? unhealthyContainerCount = null,Object? volumeCount = null,Object? imageCount = null,Object? serviceCount = null,Object? stackCount = null,Object? networkCount = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -86,6 +86,7 @@ as int,volumeCount: null == volumeCount ? _self.volumeCount : volumeCount // ign
 as int,imageCount: null == imageCount ? _self.imageCount : imageCount // ignore: cast_nullable_to_non_nullable
 as int,serviceCount: null == serviceCount ? _self.serviceCount : serviceCount // ignore: cast_nullable_to_non_nullable
 as int,stackCount: null == stackCount ? _self.stackCount : stackCount // ignore: cast_nullable_to_non_nullable
+as int,networkCount: null == networkCount ? _self.networkCount : networkCount // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }
@@ -171,10 +172,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String name,  int type,  String url,  int status,  int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String name,  int type,  String url,  int status,  int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount,  int networkCount)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EnvironmentSummary() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount);case _:
+return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount,_that.networkCount);case _:
   return orElse();
 
 }
@@ -192,10 +193,10 @@ return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String name,  int type,  String url,  int status,  int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String name,  int type,  String url,  int status,  int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount,  int networkCount)  $default,) {final _that = this;
 switch (_that) {
 case _EnvironmentSummary():
-return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount);case _:
+return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount,_that.networkCount);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -212,10 +213,10 @@ return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String name,  int type,  String url,  int status,  int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String name,  int type,  String url,  int status,  int time,  String dockerVersion,  bool swarm,  int totalCpu,  int totalMemory,  int containerCount,  int runningContainerCount,  int stoppedContainerCount,  int healthyContainerCount,  int unhealthyContainerCount,  int volumeCount,  int imageCount,  int serviceCount,  int stackCount,  int networkCount)?  $default,) {final _that = this;
 switch (_that) {
 case _EnvironmentSummary() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount);case _:
+return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time,_that.dockerVersion,_that.swarm,_that.totalCpu,_that.totalMemory,_that.containerCount,_that.runningContainerCount,_that.stoppedContainerCount,_that.healthyContainerCount,_that.unhealthyContainerCount,_that.volumeCount,_that.imageCount,_that.serviceCount,_that.stackCount,_that.networkCount);case _:
   return null;
 
 }
@@ -227,7 +228,7 @@ return $default(_that.id,_that.name,_that.type,_that.url,_that.status,_that.time
 @JsonSerializable()
 
 class _EnvironmentSummary implements EnvironmentSummary {
-  const _EnvironmentSummary({required this.id, required this.name, required this.type, required this.url, required this.status, required this.time, required this.dockerVersion, required this.swarm, required this.totalCpu, required this.totalMemory, required this.containerCount, required this.runningContainerCount, required this.stoppedContainerCount, required this.healthyContainerCount, required this.unhealthyContainerCount, required this.volumeCount, required this.imageCount, required this.serviceCount, required this.stackCount});
+  const _EnvironmentSummary({required this.id, required this.name, required this.type, required this.url, required this.status, required this.time, required this.dockerVersion, required this.swarm, required this.totalCpu, required this.totalMemory, required this.containerCount, required this.runningContainerCount, required this.stoppedContainerCount, required this.healthyContainerCount, required this.unhealthyContainerCount, required this.volumeCount, required this.imageCount, required this.serviceCount, required this.stackCount, required this.networkCount});
   factory _EnvironmentSummary.fromJson(Map<String, dynamic> json) => _$EnvironmentSummaryFromJson(json);
 
 @override final  int id;
@@ -249,6 +250,7 @@ class _EnvironmentSummary implements EnvironmentSummary {
 @override final  int imageCount;
 @override final  int serviceCount;
 @override final  int stackCount;
+@override final  int networkCount;
 
 /// Create a copy of EnvironmentSummary
 /// with the given fields replaced by the non-null parameter values.
@@ -263,16 +265,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EnvironmentSummary&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.url, url) || other.url == url)&&(identical(other.status, status) || other.status == status)&&(identical(other.time, time) || other.time == time)&&(identical(other.dockerVersion, dockerVersion) || other.dockerVersion == dockerVersion)&&(identical(other.swarm, swarm) || other.swarm == swarm)&&(identical(other.totalCpu, totalCpu) || other.totalCpu == totalCpu)&&(identical(other.totalMemory, totalMemory) || other.totalMemory == totalMemory)&&(identical(other.containerCount, containerCount) || other.containerCount == containerCount)&&(identical(other.runningContainerCount, runningContainerCount) || other.runningContainerCount == runningContainerCount)&&(identical(other.stoppedContainerCount, stoppedContainerCount) || other.stoppedContainerCount == stoppedContainerCount)&&(identical(other.healthyContainerCount, healthyContainerCount) || other.healthyContainerCount == healthyContainerCount)&&(identical(other.unhealthyContainerCount, unhealthyContainerCount) || other.unhealthyContainerCount == unhealthyContainerCount)&&(identical(other.volumeCount, volumeCount) || other.volumeCount == volumeCount)&&(identical(other.imageCount, imageCount) || other.imageCount == imageCount)&&(identical(other.serviceCount, serviceCount) || other.serviceCount == serviceCount)&&(identical(other.stackCount, stackCount) || other.stackCount == stackCount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EnvironmentSummary&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.url, url) || other.url == url)&&(identical(other.status, status) || other.status == status)&&(identical(other.time, time) || other.time == time)&&(identical(other.dockerVersion, dockerVersion) || other.dockerVersion == dockerVersion)&&(identical(other.swarm, swarm) || other.swarm == swarm)&&(identical(other.totalCpu, totalCpu) || other.totalCpu == totalCpu)&&(identical(other.totalMemory, totalMemory) || other.totalMemory == totalMemory)&&(identical(other.containerCount, containerCount) || other.containerCount == containerCount)&&(identical(other.runningContainerCount, runningContainerCount) || other.runningContainerCount == runningContainerCount)&&(identical(other.stoppedContainerCount, stoppedContainerCount) || other.stoppedContainerCount == stoppedContainerCount)&&(identical(other.healthyContainerCount, healthyContainerCount) || other.healthyContainerCount == healthyContainerCount)&&(identical(other.unhealthyContainerCount, unhealthyContainerCount) || other.unhealthyContainerCount == unhealthyContainerCount)&&(identical(other.volumeCount, volumeCount) || other.volumeCount == volumeCount)&&(identical(other.imageCount, imageCount) || other.imageCount == imageCount)&&(identical(other.serviceCount, serviceCount) || other.serviceCount == serviceCount)&&(identical(other.stackCount, stackCount) || other.stackCount == stackCount)&&(identical(other.networkCount, networkCount) || other.networkCount == networkCount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,type,url,status,time,dockerVersion,swarm,totalCpu,totalMemory,containerCount,runningContainerCount,stoppedContainerCount,healthyContainerCount,unhealthyContainerCount,volumeCount,imageCount,serviceCount,stackCount]);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,url,status,time,dockerVersion,swarm,totalCpu,totalMemory,containerCount,runningContainerCount,stoppedContainerCount,healthyContainerCount,unhealthyContainerCount,volumeCount,imageCount,serviceCount,stackCount,networkCount]);
 
 @override
 String toString() {
-  return 'EnvironmentSummary(id: $id, name: $name, type: $type, url: $url, status: $status, time: $time, dockerVersion: $dockerVersion, swarm: $swarm, totalCpu: $totalCpu, totalMemory: $totalMemory, containerCount: $containerCount, runningContainerCount: $runningContainerCount, stoppedContainerCount: $stoppedContainerCount, healthyContainerCount: $healthyContainerCount, unhealthyContainerCount: $unhealthyContainerCount, volumeCount: $volumeCount, imageCount: $imageCount, serviceCount: $serviceCount, stackCount: $stackCount)';
+  return 'EnvironmentSummary(id: $id, name: $name, type: $type, url: $url, status: $status, time: $time, dockerVersion: $dockerVersion, swarm: $swarm, totalCpu: $totalCpu, totalMemory: $totalMemory, containerCount: $containerCount, runningContainerCount: $runningContainerCount, stoppedContainerCount: $stoppedContainerCount, healthyContainerCount: $healthyContainerCount, unhealthyContainerCount: $unhealthyContainerCount, volumeCount: $volumeCount, imageCount: $imageCount, serviceCount: $serviceCount, stackCount: $stackCount, networkCount: $networkCount)';
 }
 
 
@@ -283,7 +285,7 @@ abstract mixin class _$EnvironmentSummaryCopyWith<$Res> implements $EnvironmentS
   factory _$EnvironmentSummaryCopyWith(_EnvironmentSummary value, $Res Function(_EnvironmentSummary) _then) = __$EnvironmentSummaryCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String name, int type, String url, int status, int time, String dockerVersion, bool swarm, int totalCpu, int totalMemory, int containerCount, int runningContainerCount, int stoppedContainerCount, int healthyContainerCount, int unhealthyContainerCount, int volumeCount, int imageCount, int serviceCount, int stackCount
+ int id, String name, int type, String url, int status, int time, String dockerVersion, bool swarm, int totalCpu, int totalMemory, int containerCount, int runningContainerCount, int stoppedContainerCount, int healthyContainerCount, int unhealthyContainerCount, int volumeCount, int imageCount, int serviceCount, int stackCount, int networkCount
 });
 
 
@@ -300,7 +302,7 @@ class __$EnvironmentSummaryCopyWithImpl<$Res>
 
 /// Create a copy of EnvironmentSummary
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? url = null,Object? status = null,Object? time = null,Object? dockerVersion = null,Object? swarm = null,Object? totalCpu = null,Object? totalMemory = null,Object? containerCount = null,Object? runningContainerCount = null,Object? stoppedContainerCount = null,Object? healthyContainerCount = null,Object? unhealthyContainerCount = null,Object? volumeCount = null,Object? imageCount = null,Object? serviceCount = null,Object? stackCount = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? url = null,Object? status = null,Object? time = null,Object? dockerVersion = null,Object? swarm = null,Object? totalCpu = null,Object? totalMemory = null,Object? containerCount = null,Object? runningContainerCount = null,Object? stoppedContainerCount = null,Object? healthyContainerCount = null,Object? unhealthyContainerCount = null,Object? volumeCount = null,Object? imageCount = null,Object? serviceCount = null,Object? stackCount = null,Object? networkCount = null,}) {
   return _then(_EnvironmentSummary(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -321,6 +323,7 @@ as int,volumeCount: null == volumeCount ? _self.volumeCount : volumeCount // ign
 as int,imageCount: null == imageCount ? _self.imageCount : imageCount // ignore: cast_nullable_to_non_nullable
 as int,serviceCount: null == serviceCount ? _self.serviceCount : serviceCount // ignore: cast_nullable_to_non_nullable
 as int,stackCount: null == stackCount ? _self.stackCount : stackCount // ignore: cast_nullable_to_non_nullable
+as int,networkCount: null == networkCount ? _self.networkCount : networkCount // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }

--- a/lib/domain/models/environment/environment_summary.g.dart
+++ b/lib/domain/models/environment/environment_summary.g.dart
@@ -27,6 +27,7 @@ _EnvironmentSummary _$EnvironmentSummaryFromJson(Map<String, dynamic> json) =>
       imageCount: (json['imageCount'] as num).toInt(),
       serviceCount: (json['serviceCount'] as num).toInt(),
       stackCount: (json['stackCount'] as num).toInt(),
+      networkCount: (json['networkCount'] as num).toInt(),
     );
 
 Map<String, dynamic> _$EnvironmentSummaryToJson(_EnvironmentSummary instance) =>
@@ -50,4 +51,5 @@ Map<String, dynamic> _$EnvironmentSummaryToJson(_EnvironmentSummary instance) =>
       'imageCount': instance.imageCount,
       'serviceCount': instance.serviceCount,
       'stackCount': instance.stackCount,
+      'networkCount': instance.networkCount,
     };

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,13 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   late final ValueNotifier<ThemeSettings> settings;
+  late final GoRouter _router;
+
+  static final List<LocalizationsDelegate<dynamic>> _localizationsDelegates = [
+    GlobalWidgetsLocalizations.delegate,
+    GlobalMaterialLocalizations.delegate,
+    AppLocalizationDelegate(),
+  ];
 
   @override
   void initState() {
@@ -35,9 +42,10 @@ class _MyAppState extends State<MyApp> {
         widget.initialSettings ??
         ThemeSettings(sourceColor: Colors.blue, themeMode: ThemeMode.system);
     settings = ValueNotifier(init);
+    // Initialize router once; providers are available since MyApp is wrapped by MultiProvider
+    _router = router(context.read());
   }
 
-  GoRouter? _router;
   @override
   Widget build(BuildContext context) {
     return DynamicColorBuilder(
@@ -55,28 +63,17 @@ class _MyAppState extends State<MyApp> {
             builder: (context, value, _) {
               final theme = ThemeProvider.of(context);
               return MaterialApp.router(
-                localizationsDelegates: [
-                  GlobalWidgetsLocalizations.delegate,
-                  GlobalMaterialLocalizations.delegate,
-                  AppLocalizationDelegate(),
-                ],
+                localizationsDelegates: _localizationsDelegates,
                 title: 'Container Monitoring',
                 theme: theme.light(settings.value.sourceColor),
                 darkTheme: theme.dark(settings.value.sourceColor),
                 themeMode: settings.value.themeMode,
-                routerConfig: _router ??= router(context.read()),
+                routerConfig: _router,
               );
             },
           ),
         ),
       ),
     );
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // Ensure the router is created once with the available AuthRepository in context
-    _router ??= router(context.read());
   }
 }

--- a/lib/routing/router.dart
+++ b/lib/routing/router.dart
@@ -1,6 +1,8 @@
 import 'package:container_monitoring/ui/auth/login/view_models/login_viewmodel.dart';
 import 'package:container_monitoring/ui/home/view_models/home_viewmodel.dart';
 import 'package:container_monitoring/ui/main_home/widgets/main_home_screen.dart';
+import 'package:container_monitoring/ui/dashboard/widgets/dashboard_screen.dart';
+import 'package:container_monitoring/ui/dashboard/view_models/dashboard_viewmodel.dart';
 import 'package:container_monitoring/ui/user/view_models/user_viewmodel.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
@@ -37,6 +39,23 @@ GoRouter router(AuthRepository authRepository) => GoRouter(
           homeViewModel: homeViewModel,
           userViewModel: userViewModel,
         );
+      },
+    ),
+    GoRoute(
+      name: 'dashboard',
+      path: Routes.dashboard,
+      builder: (context, state) {
+        final idParam = state.pathParameters['id'];
+        final id = int.tryParse(idParam ?? '');
+        if (id == null) {
+          // If id is invalid, go back to home
+          return const SizedBox.shrink();
+        }
+
+        final viewModel = DashboardViewmodel(environmentRepository: context.read());
+        viewModel.loadEnvironments.execute(id);
+        
+        return DashboardScreen(viewModel: viewModel);
       },
     ),
   ],

--- a/lib/routing/routes.dart
+++ b/lib/routing/routes.dart
@@ -1,4 +1,5 @@
 abstract final class Routes {
   static const home = '/';
   static const login = '/login';
+  static const dashboard = '/dashboard/:id';
 }

--- a/lib/ui/core/ui/fancy_card.dart
+++ b/lib/ui/core/ui/fancy_card.dart
@@ -1,22 +1,32 @@
 import 'package:flutter/material.dart';
 
 class FancyCard extends StatelessWidget {
-  const FancyCard({super.key, required this.child});
+  const FancyCard({super.key, required this.child, this.onTap});
 
   final Widget child;
+  final VoidCallback? onTap;
   static const EdgeInsets _padding = EdgeInsets.all(16);
 
   @override
   Widget build(BuildContext context) {
     final color = Theme.of(context).colorScheme.surfaceContainerHighest;
-    return Container(
-      width: double.infinity,
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: color.withValues(alpha: 0.8)),
-      ),
-      child: Padding(padding: _padding, child: child),
+    final shape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(12),
+      side: BorderSide(color: color.withValues(alpha: 0.8)),
+    );
+
+    final content = Padding(padding: _padding, child: child);
+
+    return Material(
+      color: Theme.of(context).cardColor,
+      shape: shape,
+      child: onTap == null
+          ? content
+          : InkWell(
+              borderRadius: const BorderRadius.all(Radius.circular(12)),
+              onTap: onTap,
+              child: content,
+            ),
     );
   }
 }

--- a/lib/ui/dashboard/view_models/dashboard_viewmodel.dart
+++ b/lib/ui/dashboard/view_models/dashboard_viewmodel.dart
@@ -1,0 +1,38 @@
+import 'package:container_monitoring/data/repositories/environment/environment.dart';
+import 'package:container_monitoring/domain/models/environment/environment_summary.dart';
+import 'package:container_monitoring/utils/command.dart';
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+import '../../../utils/result.dart';
+
+class DashboardViewmodel extends ChangeNotifier {
+  DashboardViewmodel({required EnvironmentRepository environmentRepository})
+    : _environmentRepository = environmentRepository {
+    loadEnvironments = Command1(_load);
+  }
+
+  final EnvironmentRepository _environmentRepository;
+  final _log = Logger('DashboardViewmodel');
+
+  EnvironmentSummary? _environment;
+
+  EnvironmentSummary? get environment => _environment;
+
+  late final Command1<void, int> loadEnvironments;
+
+  Future<Result<void>> _load(int id) async {
+    final result = await _environmentRepository.getEnvironment(id);
+    switch (result) {
+      case Ok<EnvironmentSummary>():
+        _environment = result.value;
+        _log.fine('Loaded environment details for ID: $id');
+        notifyListeners();
+      case Error<EnvironmentSummary>():
+        _log.warning(
+          'Failed to load environment details for ID: $id',
+          result.error,
+        );
+    }
+    return result;
+  }
+}

--- a/lib/ui/dashboard/widgets/action_info_card.dart
+++ b/lib/ui/dashboard/widgets/action_info_card.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:container_monitoring/ui/core/ui/fancy_card.dart';
+
+class ActionInfoCard extends StatelessWidget {
+  const ActionInfoCard({
+    super.key,
+    required this.icon,
+    required this.value,
+    required this.title,
+    this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String value;
+  final String title;
+  final String? subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return FancyCard(
+      onTap: onTap,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Row(
+                children: [
+                  Icon(icon),
+                  const SizedBox(width: 8),
+                  Text(title, style: Theme.of(context).textTheme.titleSmall),
+                ],
+              ),
+              Text(
+                value,
+                style: Theme.of(context)
+                    .textTheme
+                    .titleSmall
+              ),
+            ],
+          ),
+          if (subtitle != null) ...[
+            const SizedBox(height: 4),
+            Text(subtitle!, style: Theme.of(context).textTheme.bodySmall),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+

--- a/lib/ui/dashboard/widgets/dashboard_screen.dart
+++ b/lib/ui/dashboard/widgets/dashboard_screen.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:container_monitoring/routing/routes.dart';
+import 'package:container_monitoring/ui/dashboard/view_models/dashboard_viewmodel.dart';
+import 'package:container_monitoring/ui/dashboard/widgets/environment_info_card.dart';
+import 'package:container_monitoring/ui/dashboard/widgets/action_info_card.dart';
+
+class DashboardScreen extends StatefulWidget {
+  const DashboardScreen({super.key, required this.viewModel});
+
+  final DashboardViewmodel viewModel;
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final vm = widget.viewModel;
+    return ListenableBuilder(
+      listenable: vm,
+      builder: (context, _) {
+        final env = vm.environment;
+        return Scaffold(
+          appBar: AppBar(
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () => context.go(Routes.home),
+            ),
+            title: Text(env?.name ?? 'Dashboard'),
+          ),
+          body: env == null
+              ? const Center(child: CircularProgressIndicator())
+              : LayoutBuilder(
+                  builder: (context, constraints) {
+                    final width = constraints.maxWidth;
+                    final crossAxisCount = width >= 1200
+                        ? 3
+                        : width >= 700
+                        ? 2
+                        : 1;
+                    const horizontalPadding = 24.0; // 12 left + 12 right
+                    const spacing = 12.0;
+                    final totalSpacing = spacing * (crossAxisCount - 1);
+                    final itemWidth =
+                        (width - horizontalPadding - totalSpacing) /
+                        crossAxisCount;
+                    return SingleChildScrollView(
+                      padding: const EdgeInsets.all(12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          EnvironmentInfoCard(env: env),
+                          const SizedBox(height: 12),
+                          Wrap(
+                            spacing: spacing,
+                            runSpacing: spacing,
+                            children: [
+                              SizedBox(
+                                width: itemWidth,
+                                child: ActionInfoCard(
+                                  icon: Icons.layers_outlined,
+                                  value: env.stackCount.toString(),
+                                  title: 'Stacks',
+                                  onTap: () {},
+                                ),
+                              ),
+                              SizedBox(
+                                width: itemWidth,
+                                child: ActionInfoCard(
+                                  icon: Icons.apps_outlined,
+                                  value: env.containerCount.toString(),
+                                  title: 'Containers',
+                                  subtitle:
+                                      '${env.runningContainerCount} running   ${env.stoppedContainerCount} stopped\n${env.healthyContainerCount} healthy   ${env.unhealthyContainerCount} unhealthy',
+                                  onTap: () {},
+                                ),
+                              ),
+                              SizedBox(
+                                width: itemWidth,
+                                child: ActionInfoCard(
+                                  icon: Icons.sd_card_outlined,
+                                  value: env.imageCount.toString(),
+                                  title: 'Images',
+                                  onTap: () {},
+                                ),
+                              ),
+                              SizedBox(
+                                width: itemWidth,
+                                child: ActionInfoCard(
+                                  icon: Icons.folder_outlined,
+                                  value: env.volumeCount.toString(),
+                                  title: 'Volumes',
+                                  onTap: () {},
+                                ),
+                              ),
+                              SizedBox(
+                                width: itemWidth,
+                                child: ActionInfoCard(
+                                  icon: Icons.account_tree_outlined,
+                                  value: ' ${env.networkCount}',
+                                  title: 'Networks',
+                                  onTap: () {},
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+        );
+      },
+    );
+  }
+}
+
+String _formatMemoryShort(int bytes) {
+  final gb = bytes / 1000 / 1000 / 1000;
+  if (gb >= 1) return '${gb.toStringAsFixed(1)} GB';
+  final mb = bytes / 1000 / 1000;
+  if (mb >= 1) return '${mb.toStringAsFixed(1)} MB';
+  final kb = bytes / 1000;
+  return '${kb.toStringAsFixed(1)} KB';
+}

--- a/lib/ui/dashboard/widgets/environment_info_card.dart
+++ b/lib/ui/dashboard/widgets/environment_info_card.dart
@@ -1,0 +1,87 @@
+import 'package:container_monitoring/domain/models/environment/environment_summary.dart';
+import 'package:flutter/material.dart';
+import 'package:container_monitoring/ui/core/ui/fancy_card.dart';
+
+class EnvironmentInfoCard extends StatelessWidget {
+  const EnvironmentInfoCard({super.key, required this.env});
+
+  final EnvironmentSummary env; // EnvironmentSummary
+
+  @override
+  Widget build(BuildContext context) {
+    return FancyCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.info_outline),
+              const SizedBox(width: 8),
+              Text(
+                'Environment info',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _InfoRow(label: 'Environment', value: env.name),
+          _InfoRow(label: 'URL', value: env.url),
+          _InfoRow(label: 'GPU', value: 'none'),
+          _InfoRow(label: 'Tags', value: '-'),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 16,
+            runSpacing: 8,
+            children: [
+              _ChipStat(
+                icon: Icons.memory,
+                label: '${(env.totalMemory / 1000 / 1000 / 1000).toStringAsFixed(1)} GB',
+              ),
+              _ChipStat(icon: Icons.speed, label: '${env.totalCpu} vCPU'),
+              _ChipStat(icon: Icons.settings, label: 'v${env.dockerVersion}'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 120,
+            child: Text(label, style: Theme.of(context).textTheme.bodyMedium),
+          ),
+          Expanded(
+            child: Text(value, style: Theme.of(context).textTheme.bodyMedium),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChipStat extends StatelessWidget {
+  const _ChipStat({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(label: Text(label), avatar: Icon(icon, size: 18));
+  }
+}
+
+

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:container_monitoring/ui/core/ui/fancy_card.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:container_monitoring/domain/models/environment/environment_summary.dart';
 import 'package:container_monitoring/ui/home/view_models/home_viewmodel.dart';
@@ -136,27 +137,27 @@ class EnvironmentCard extends StatelessWidget {
             runSpacing: 8,
             children: [
               _StatItem(
-                icon: Icons.layers,
+                icon: Icons.layers_outlined,
                 label: '${environment.stackCount} stacks',
               ),
               _StatItem(
-                icon: Icons.storage,
+                icon: Icons.apps_outlined,
                 label: '${environment.containerCount} containers',
               ),
               _StatItem(
-                icon: Icons.folder,
+                icon: Icons.folder_outlined,
                 label: '${environment.volumeCount} volumes',
               ),
               _StatItem(
-                icon: Icons.list,
+                icon: Icons.sd_storage_outlined,
                 label: '${environment.imageCount} images',
               ),
               _StatItem(
-                icon: Icons.memory,
+                icon: Icons.memory_outlined,
                 label: '${environment.totalCpu} CPU',
               ),
               _StatItem(
-                icon: Icons.sd_storage,
+                icon: Icons.storage_outlined,
                 label:
                     '${(environment.totalMemory / 1000 / 1000 / 1000).toStringAsFixed(1)} GB RAM',
               ),
@@ -167,8 +168,9 @@ class EnvironmentCard extends StatelessWidget {
 
           // Bottom status
           Row(
-            mainAxisAlignment: MainAxisAlignment.end,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
+              // Left: connection status
               Container(
                 padding: const EdgeInsets.symmetric(
                   horizontal: 10,
@@ -183,9 +185,20 @@ class EnvironmentCard extends StatelessWidget {
                         ? const _PulsingDot()
                         : const Icon(Icons.circle, color: Colors.red, size: 10),
                     const SizedBox(width: 6),
-                    const Text('Connected', style: TextStyle(fontSize: 13)),
+                    Text(
+                      isRunning ? 'Connected' : 'Disconnected',
+                      style: const TextStyle(fontSize: 13),
+                    ),
                   ],
                 ),
+              ),
+
+              // Right: dashboard button
+              OutlinedButton.icon(
+                onPressed: () {
+                  context.push('/dashboard/${environment.id}');
+                },
+                label: const Text('Dashboard'),
               ),
             ],
           ),


### PR DESCRIPTION
This pull request adds support for retrieving detailed information about a specific environment by its ID and enhances the `EnvironmentSummary` model to include the number of networks. It introduces a new API method for fetching a single environment, updates the repository interfaces and implementations, and ensures the data model and its generated code reflect the new `networkCount` field.

The most important changes are:

**API and Repository Enhancements:**
* Added a `getEnvironment(int id)` method to the `EnvironmentRepository` interface and implemented it in `EnvironmentRepositoryRemote`, enabling fetching details for a single environment by ID. [[1]](diffhunk://#diff-c7880daa8b823ac386a31a843f6ee52426e16cfe94e0d70b09a392b7e596e156R9-R11) [[2]](diffhunk://#diff-78daba57824a0965e75360a21c94e598c18a939e06aae45c9288304c92950d12R62-R106)
* Implemented the `getEnvironment` API call in `ApiClient`, including error handling and support for authentication refresh.

**Model Updates:**
* Extended the `EnvironmentSummary` data class to include a new `networkCount` field, and updated its constructor accordingly.
* Updated the generated `environment_summary.freezed.dart` code to support the new `networkCount` property throughout equality, copy, and serialization logic. [[1]](diffhunk://#diff-a6cc840391fc6aaa402607712b9570896ec83f2af7e84dadcd28e898108b3be6L18-R18) [[2]](diffhunk://#diff-a6cc840391fc6aaa402607712b9570896ec83f2af7e84dadcd28e898108b3be6L31-R40) [[3]](diffhunk://#diff-a6cc840391fc6aaa402607712b9570896ec83f2af7e84dadcd28e898108b3be6L51-R51) [[4]](diffhunk://#diff-a6cc840391fc6aaa402607712b9570896ec83f2af7e84dadcd28e898108b3be6L68-R68) [[5]](diffhunk://#diff-a6cc840391fc6aaa402607712b9570896ec83f2af7e84dadcd28e898108b3be6R89) [[6]](diffhunk://#diff-a6cc840391fc6aaa402607712b9570896ec83f2af7e84dadcd28e898108b3be6L174-R178) [[7]](diffhunk://#diff-a6cc840391fc6aaa402607712b9570896ec83f2af7e84dadcd28e898108b3be6L195-R199) [[8]](diffhunk://#diff-a6cc840391fc6aaa402607712b9570896ec83f2af7e84dadcd28e898108b3be6L215-R219)

**Data Mapping:**
* Modified the mapping logic in `EnvironmentRepositoryRemote` to populate the new `networkCount` field from the API response when listing environments.

**Minor Improvements:**
* Improved formatting and error handling in the `ApiClient` methods for listing environments. [[1]](diffhunk://#diff-aa920cd02f8a8284b25593feb51ddfd971c61376c4c887d296aed7a54ab55f5eL95-R102) [[2]](diffhunk://#diff-aa920cd02f8a8284b25593feb51ddfd971c61376c4c887d296aed7a54ab55f5eR111-R158)