### PR TITLE
feat: volume

### DIFF
--- a/lib/config/dependencies.dart
+++ b/lib/config/dependencies.dart
@@ -10,11 +10,11 @@ import '../data/repositories/environment/environment.dart';
 import '../data/repositories/environment/environment_remote.dart';
 import '../data/repositories/user/user_repository.dart';
 import '../data/repositories/user/user_repository_remote.dart';
+import '../data/repositories/volume/volume.dart';
+import '../data/repositories/volume/volume_remote.dart';
 
 /// Shared providers for all configurations.
-List<SingleChildWidget> _sharedProviders = [
-];
-
+List<SingleChildWidget> _sharedProviders = [];
 
 List<SingleChildWidget> get providersRemote {
   return [
@@ -25,7 +25,8 @@ List<SingleChildWidget> get providersRemote {
       create: (context) {
         final authApiClient = context.read<AuthApiClient>();
         final apiClient = context.read<ApiClient>();
-        final sharedPreferencesService = context.read<SharedPreferencesService>();
+        final sharedPreferencesService = context
+            .read<SharedPreferencesService>();
         final repo = AuthRepositoryRemote(
           authApiClient: authApiClient,
           apiClient: apiClient,
@@ -39,13 +40,17 @@ List<SingleChildWidget> get providersRemote {
       },
     ),
     Provider(
-      create: (context) => 
-        EnvironmentRepositoryRemote(apiClient: context.read())
-          as EnvironmentRepository,
+      create: (context) =>
+          EnvironmentRepositoryRemote(apiClient: context.read())
+              as EnvironmentRepository,
     ),
-    Provider(create: (context) => 
-        UserRepositoryRemote(apiClient: context.read())
-          as UserRepository,
+    Provider(
+      create: (context) =>
+          UserRepositoryRemote(apiClient: context.read()) as UserRepository,
+    ),
+    Provider(
+      create: (context) =>
+          VolumeRepositoryRemote(apiClient: context.read()) as VolumeRepository,
     ),
     ..._sharedProviders,
   ];

--- a/lib/data/repositories/volume/volume.dart
+++ b/lib/data/repositories/volume/volume.dart
@@ -1,0 +1,9 @@
+import 'package:container_monitoring/domain/models/volume/volume.dart' as volume_model;
+import 'package:container_monitoring/utils/result.dart';
+
+abstract class VolumeRepository {
+  Future<Result<List<volume_model.Volume>>> listVolumesByEnvironment(int environmentId);
+
+  Future<Result<volume_model.Volume>> getVolumeByName(int environmentId, String volumeName);
+}
+

--- a/lib/data/repositories/volume/volume_remote.dart
+++ b/lib/data/repositories/volume/volume_remote.dart
@@ -1,0 +1,89 @@
+import 'package:container_monitoring/data/repositories/volume/volume.dart';
+import 'package:container_monitoring/data/services/api/api_client.dart';
+import 'package:container_monitoring/data/services/api/models/volume/volume_api_model.dart';
+import 'package:container_monitoring/domain/models/volume/volume.dart' as volume_model;
+import '../../../utils/result.dart';
+
+class VolumeRepositoryRemote extends VolumeRepository {
+  VolumeRepositoryRemote({required ApiClient apiClient})
+    : _apiClient = apiClient;
+
+  final ApiClient _apiClient;
+
+  @override
+  Future<Result<List<volume_model.Volume>>> listVolumesByEnvironment(
+    int environmentId,
+  ) async {
+    try {
+      final result = await _apiClient.listVolumesByEnvironment(environmentId);
+      switch (result) {
+        case Error<List<VolumeApiModel>>():
+          return Result.error(result.error);
+        case Ok<List<VolumeApiModel>>():
+      }
+      final volumesApi = result.value;
+      return Result.ok(
+        volumesApi
+            .map(
+              (volumeApi) => volume_model.Volume(
+                createdAt: volumeApi.createdAt,
+                driver: volumeApi.driver,
+                labels: volumeApi.labels,
+                mountpoint: volumeApi.mountpoint,
+                name: volumeApi.name,
+                scope: volumeApi.scope,
+                resourceID: volumeApi.resourceID,
+                stack: volumeApi.labels != null
+                    ? volumeApi.labels!['com.docker.compose.project']
+                    : null,
+              ),
+            )
+            .toList(),
+      );
+    } on Exception catch (error) {
+      return Result.error(error);
+    }
+  }
+
+  @override
+  Future<Result<volume_model.Volume>> getVolumeByName(int environmentId, String volumeName) async {
+    try {
+      final result = await _apiClient.getVolumeByName(environmentId, volumeName);
+      switch (result) {
+        case Error<VolumeApiModel>():
+          return Result.error(result.error);
+        case Ok<VolumeApiModel>():
+      }
+      final volumeApi = result.value;
+      return Result.ok(volume_model.Volume(
+        createdAt: volumeApi.createdAt,
+        driver: volumeApi.driver,
+        labels: volumeApi.labels,
+        mountpoint: volumeApi.mountpoint,
+        name: volumeApi.name,
+        resourceID: volumeApi.resourceID,
+        scope: volumeApi.scope,
+        stack: volumeApi.labels != null
+            ? volumeApi.labels!['com.docker.compose.project']
+            : null,
+        portainer: volumeApi.portainer != null
+            ? volume_model.PortainerInfo(
+                resourceControl: volume_model.ResourceControlInfo(
+                  id: volumeApi.portainer!.resourceControl.id,
+                  resourceId: volumeApi.portainer!.resourceControl.resourceId,
+                  subResourceIds: volumeApi.portainer!.resourceControl.subResourceIds,
+                  type: volumeApi.portainer!.resourceControl.type,
+                  userAccesses: volumeApi.portainer!.resourceControl.userAccesses,
+                  teamAccesses: volumeApi.portainer!.resourceControl.teamAccesses,
+                  public: volumeApi.portainer!.resourceControl.public,
+                  administratorsOnly: volumeApi.portainer!.resourceControl.administratorsOnly,
+                  system: volumeApi.portainer!.resourceControl.system,
+                ),
+              )
+            : null,
+      ));
+    } on Exception catch (error) {
+      return Result.error(error);
+    }
+  }
+}

--- a/lib/data/services/api/models/volume/volume_api_model.dart
+++ b/lib/data/services/api/models/volume/volume_api_model.dart
@@ -1,0 +1,53 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'volume_api_model.freezed.dart';
+part 'volume_api_model.g.dart';
+
+@freezed
+abstract class VolumeApiModel with _$VolumeApiModel {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
+  const factory VolumeApiModel({
+    required String createdAt,
+    required String driver,
+    Map<String, String>? labels,
+    required String mountpoint,
+    required String name,
+    Map<String, dynamic>? options,
+    String? resourceID,
+    required String scope,
+    PortainerInfo? portainer,
+  }) = _VolumeApiModel;
+
+  factory VolumeApiModel.fromJson(Map<String, dynamic> json) =>
+      _$VolumeApiModelFromJson(json);
+}
+
+@freezed
+abstract class PortainerInfo with _$PortainerInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
+  const factory PortainerInfo({
+    required ResourceControlInfo resourceControl,
+  }) = _PortainerInfo;
+
+  factory PortainerInfo.fromJson(Map<String, dynamic> json) =>
+      _$PortainerInfoFromJson(json);
+}
+
+@freezed
+abstract class ResourceControlInfo with _$ResourceControlInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
+  const factory ResourceControlInfo({
+    required int id,
+    required String resourceId,
+    required List<String> subResourceIds,
+    required int type,
+    required List<dynamic> userAccesses,
+    required List<dynamic> teamAccesses,
+    required bool public,
+    required bool administratorsOnly,
+    required bool system,
+  }) = _ResourceControlInfo;
+
+  factory ResourceControlInfo.fromJson(Map<String, dynamic> json) =>
+      _$ResourceControlInfoFromJson(json);
+}

--- a/lib/data/services/api/models/volume/volume_api_model.freezed.dart
+++ b/lib/data/services/api/models/volume/volume_api_model.freezed.dart
@@ -1,0 +1,927 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'volume_api_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$VolumeApiModel {
+
+ String get createdAt; String get driver; Map<String, String>? get labels; String get mountpoint; String get name; Map<String, dynamic>? get options; String? get resourceID; String get scope; PortainerInfo? get portainer;
+/// Create a copy of VolumeApiModel
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VolumeApiModelCopyWith<VolumeApiModel> get copyWith => _$VolumeApiModelCopyWithImpl<VolumeApiModel>(this as VolumeApiModel, _$identity);
+
+  /// Serializes this VolumeApiModel to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VolumeApiModel&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.driver, driver) || other.driver == driver)&&const DeepCollectionEquality().equals(other.labels, labels)&&(identical(other.mountpoint, mountpoint) || other.mountpoint == mountpoint)&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other.options, options)&&(identical(other.resourceID, resourceID) || other.resourceID == resourceID)&&(identical(other.scope, scope) || other.scope == scope)&&(identical(other.portainer, portainer) || other.portainer == portainer));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,createdAt,driver,const DeepCollectionEquality().hash(labels),mountpoint,name,const DeepCollectionEquality().hash(options),resourceID,scope,portainer);
+
+@override
+String toString() {
+  return 'VolumeApiModel(createdAt: $createdAt, driver: $driver, labels: $labels, mountpoint: $mountpoint, name: $name, options: $options, resourceID: $resourceID, scope: $scope, portainer: $portainer)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $VolumeApiModelCopyWith<$Res>  {
+  factory $VolumeApiModelCopyWith(VolumeApiModel value, $Res Function(VolumeApiModel) _then) = _$VolumeApiModelCopyWithImpl;
+@useResult
+$Res call({
+ String createdAt, String driver, Map<String, String>? labels, String mountpoint, String name, Map<String, dynamic>? options, String? resourceID, String scope, PortainerInfo? portainer
+});
+
+
+$PortainerInfoCopyWith<$Res>? get portainer;
+
+}
+/// @nodoc
+class _$VolumeApiModelCopyWithImpl<$Res>
+    implements $VolumeApiModelCopyWith<$Res> {
+  _$VolumeApiModelCopyWithImpl(this._self, this._then);
+
+  final VolumeApiModel _self;
+  final $Res Function(VolumeApiModel) _then;
+
+/// Create a copy of VolumeApiModel
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? createdAt = null,Object? driver = null,Object? labels = freezed,Object? mountpoint = null,Object? name = null,Object? options = freezed,Object? resourceID = freezed,Object? scope = null,Object? portainer = freezed,}) {
+  return _then(_self.copyWith(
+createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as String,driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
+as String,labels: freezed == labels ? _self.labels : labels // ignore: cast_nullable_to_non_nullable
+as Map<String, String>?,mountpoint: null == mountpoint ? _self.mountpoint : mountpoint // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,options: freezed == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,resourceID: freezed == resourceID ? _self.resourceID : resourceID // ignore: cast_nullable_to_non_nullable
+as String?,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
+as String,portainer: freezed == portainer ? _self.portainer : portainer // ignore: cast_nullable_to_non_nullable
+as PortainerInfo?,
+  ));
+}
+/// Create a copy of VolumeApiModel
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PortainerInfoCopyWith<$Res>? get portainer {
+    if (_self.portainer == null) {
+    return null;
+  }
+
+  return $PortainerInfoCopyWith<$Res>(_self.portainer!, (value) {
+    return _then(_self.copyWith(portainer: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [VolumeApiModel].
+extension VolumeApiModelPatterns on VolumeApiModel {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _VolumeApiModel value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _VolumeApiModel() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _VolumeApiModel value)  $default,){
+final _that = this;
+switch (_that) {
+case _VolumeApiModel():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _VolumeApiModel value)?  $default,){
+final _that = this;
+switch (_that) {
+case _VolumeApiModel() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String createdAt,  String driver,  Map<String, String>? labels,  String mountpoint,  String name,  Map<String, dynamic>? options,  String? resourceID,  String scope,  PortainerInfo? portainer)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _VolumeApiModel() when $default != null:
+return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that.name,_that.options,_that.resourceID,_that.scope,_that.portainer);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String createdAt,  String driver,  Map<String, String>? labels,  String mountpoint,  String name,  Map<String, dynamic>? options,  String? resourceID,  String scope,  PortainerInfo? portainer)  $default,) {final _that = this;
+switch (_that) {
+case _VolumeApiModel():
+return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that.name,_that.options,_that.resourceID,_that.scope,_that.portainer);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String createdAt,  String driver,  Map<String, String>? labels,  String mountpoint,  String name,  Map<String, dynamic>? options,  String? resourceID,  String scope,  PortainerInfo? portainer)?  $default,) {final _that = this;
+switch (_that) {
+case _VolumeApiModel() when $default != null:
+return $default(_that.createdAt,_that.driver,_that.labels,_that.mountpoint,_that.name,_that.options,_that.resourceID,_that.scope,_that.portainer);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.pascal)
+class _VolumeApiModel implements VolumeApiModel {
+  const _VolumeApiModel({required this.createdAt, required this.driver, final  Map<String, String>? labels, required this.mountpoint, required this.name, final  Map<String, dynamic>? options, this.resourceID, required this.scope, this.portainer}): _labels = labels,_options = options;
+  factory _VolumeApiModel.fromJson(Map<String, dynamic> json) => _$VolumeApiModelFromJson(json);
+
+@override final  String createdAt;
+@override final  String driver;
+ final  Map<String, String>? _labels;
+@override Map<String, String>? get labels {
+  final value = _labels;
+  if (value == null) return null;
+  if (_labels is EqualUnmodifiableMapView) return _labels;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+@override final  String mountpoint;
+@override final  String name;
+ final  Map<String, dynamic>? _options;
+@override Map<String, dynamic>? get options {
+  final value = _options;
+  if (value == null) return null;
+  if (_options is EqualUnmodifiableMapView) return _options;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+@override final  String? resourceID;
+@override final  String scope;
+@override final  PortainerInfo? portainer;
+
+/// Create a copy of VolumeApiModel
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VolumeApiModelCopyWith<_VolumeApiModel> get copyWith => __$VolumeApiModelCopyWithImpl<_VolumeApiModel>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$VolumeApiModelToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VolumeApiModel&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.driver, driver) || other.driver == driver)&&const DeepCollectionEquality().equals(other._labels, _labels)&&(identical(other.mountpoint, mountpoint) || other.mountpoint == mountpoint)&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other._options, _options)&&(identical(other.resourceID, resourceID) || other.resourceID == resourceID)&&(identical(other.scope, scope) || other.scope == scope)&&(identical(other.portainer, portainer) || other.portainer == portainer));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,createdAt,driver,const DeepCollectionEquality().hash(_labels),mountpoint,name,const DeepCollectionEquality().hash(_options),resourceID,scope,portainer);
+
+@override
+String toString() {
+  return 'VolumeApiModel(createdAt: $createdAt, driver: $driver, labels: $labels, mountpoint: $mountpoint, name: $name, options: $options, resourceID: $resourceID, scope: $scope, portainer: $portainer)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$VolumeApiModelCopyWith<$Res> implements $VolumeApiModelCopyWith<$Res> {
+  factory _$VolumeApiModelCopyWith(_VolumeApiModel value, $Res Function(_VolumeApiModel) _then) = __$VolumeApiModelCopyWithImpl;
+@override @useResult
+$Res call({
+ String createdAt, String driver, Map<String, String>? labels, String mountpoint, String name, Map<String, dynamic>? options, String? resourceID, String scope, PortainerInfo? portainer
+});
+
+
+@override $PortainerInfoCopyWith<$Res>? get portainer;
+
+}
+/// @nodoc
+class __$VolumeApiModelCopyWithImpl<$Res>
+    implements _$VolumeApiModelCopyWith<$Res> {
+  __$VolumeApiModelCopyWithImpl(this._self, this._then);
+
+  final _VolumeApiModel _self;
+  final $Res Function(_VolumeApiModel) _then;
+
+/// Create a copy of VolumeApiModel
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? createdAt = null,Object? driver = null,Object? labels = freezed,Object? mountpoint = null,Object? name = null,Object? options = freezed,Object? resourceID = freezed,Object? scope = null,Object? portainer = freezed,}) {
+  return _then(_VolumeApiModel(
+createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as String,driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
+as String,labels: freezed == labels ? _self._labels : labels // ignore: cast_nullable_to_non_nullable
+as Map<String, String>?,mountpoint: null == mountpoint ? _self.mountpoint : mountpoint // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,options: freezed == options ? _self._options : options // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,resourceID: freezed == resourceID ? _self.resourceID : resourceID // ignore: cast_nullable_to_non_nullable
+as String?,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
+as String,portainer: freezed == portainer ? _self.portainer : portainer // ignore: cast_nullable_to_non_nullable
+as PortainerInfo?,
+  ));
+}
+
+/// Create a copy of VolumeApiModel
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PortainerInfoCopyWith<$Res>? get portainer {
+    if (_self.portainer == null) {
+    return null;
+  }
+
+  return $PortainerInfoCopyWith<$Res>(_self.portainer!, (value) {
+    return _then(_self.copyWith(portainer: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$PortainerInfo {
+
+ ResourceControlInfo get resourceControl;
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PortainerInfoCopyWith<PortainerInfo> get copyWith => _$PortainerInfoCopyWithImpl<PortainerInfo>(this as PortainerInfo, _$identity);
+
+  /// Serializes this PortainerInfo to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PortainerInfo&&(identical(other.resourceControl, resourceControl) || other.resourceControl == resourceControl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,resourceControl);
+
+@override
+String toString() {
+  return 'PortainerInfo(resourceControl: $resourceControl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PortainerInfoCopyWith<$Res>  {
+  factory $PortainerInfoCopyWith(PortainerInfo value, $Res Function(PortainerInfo) _then) = _$PortainerInfoCopyWithImpl;
+@useResult
+$Res call({
+ ResourceControlInfo resourceControl
+});
+
+
+$ResourceControlInfoCopyWith<$Res> get resourceControl;
+
+}
+/// @nodoc
+class _$PortainerInfoCopyWithImpl<$Res>
+    implements $PortainerInfoCopyWith<$Res> {
+  _$PortainerInfoCopyWithImpl(this._self, this._then);
+
+  final PortainerInfo _self;
+  final $Res Function(PortainerInfo) _then;
+
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? resourceControl = null,}) {
+  return _then(_self.copyWith(
+resourceControl: null == resourceControl ? _self.resourceControl : resourceControl // ignore: cast_nullable_to_non_nullable
+as ResourceControlInfo,
+  ));
+}
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ResourceControlInfoCopyWith<$Res> get resourceControl {
+  
+  return $ResourceControlInfoCopyWith<$Res>(_self.resourceControl, (value) {
+    return _then(_self.copyWith(resourceControl: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [PortainerInfo].
+extension PortainerInfoPatterns on PortainerInfo {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PortainerInfo value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PortainerInfo() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PortainerInfo value)  $default,){
+final _that = this;
+switch (_that) {
+case _PortainerInfo():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PortainerInfo value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PortainerInfo() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( ResourceControlInfo resourceControl)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PortainerInfo() when $default != null:
+return $default(_that.resourceControl);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( ResourceControlInfo resourceControl)  $default,) {final _that = this;
+switch (_that) {
+case _PortainerInfo():
+return $default(_that.resourceControl);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( ResourceControlInfo resourceControl)?  $default,) {final _that = this;
+switch (_that) {
+case _PortainerInfo() when $default != null:
+return $default(_that.resourceControl);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.pascal)
+class _PortainerInfo implements PortainerInfo {
+  const _PortainerInfo({required this.resourceControl});
+  factory _PortainerInfo.fromJson(Map<String, dynamic> json) => _$PortainerInfoFromJson(json);
+
+@override final  ResourceControlInfo resourceControl;
+
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PortainerInfoCopyWith<_PortainerInfo> get copyWith => __$PortainerInfoCopyWithImpl<_PortainerInfo>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PortainerInfoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PortainerInfo&&(identical(other.resourceControl, resourceControl) || other.resourceControl == resourceControl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,resourceControl);
+
+@override
+String toString() {
+  return 'PortainerInfo(resourceControl: $resourceControl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PortainerInfoCopyWith<$Res> implements $PortainerInfoCopyWith<$Res> {
+  factory _$PortainerInfoCopyWith(_PortainerInfo value, $Res Function(_PortainerInfo) _then) = __$PortainerInfoCopyWithImpl;
+@override @useResult
+$Res call({
+ ResourceControlInfo resourceControl
+});
+
+
+@override $ResourceControlInfoCopyWith<$Res> get resourceControl;
+
+}
+/// @nodoc
+class __$PortainerInfoCopyWithImpl<$Res>
+    implements _$PortainerInfoCopyWith<$Res> {
+  __$PortainerInfoCopyWithImpl(this._self, this._then);
+
+  final _PortainerInfo _self;
+  final $Res Function(_PortainerInfo) _then;
+
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? resourceControl = null,}) {
+  return _then(_PortainerInfo(
+resourceControl: null == resourceControl ? _self.resourceControl : resourceControl // ignore: cast_nullable_to_non_nullable
+as ResourceControlInfo,
+  ));
+}
+
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ResourceControlInfoCopyWith<$Res> get resourceControl {
+  
+  return $ResourceControlInfoCopyWith<$Res>(_self.resourceControl, (value) {
+    return _then(_self.copyWith(resourceControl: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$ResourceControlInfo {
+
+ int get id; String get resourceId; List<String> get subResourceIds; int get type; List<dynamic> get userAccesses; List<dynamic> get teamAccesses; bool get public; bool get administratorsOnly; bool get system;
+/// Create a copy of ResourceControlInfo
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ResourceControlInfoCopyWith<ResourceControlInfo> get copyWith => _$ResourceControlInfoCopyWithImpl<ResourceControlInfo>(this as ResourceControlInfo, _$identity);
+
+  /// Serializes this ResourceControlInfo to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ResourceControlInfo&&(identical(other.id, id) || other.id == id)&&(identical(other.resourceId, resourceId) || other.resourceId == resourceId)&&const DeepCollectionEquality().equals(other.subResourceIds, subResourceIds)&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other.userAccesses, userAccesses)&&const DeepCollectionEquality().equals(other.teamAccesses, teamAccesses)&&(identical(other.public, public) || other.public == public)&&(identical(other.administratorsOnly, administratorsOnly) || other.administratorsOnly == administratorsOnly)&&(identical(other.system, system) || other.system == system));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,resourceId,const DeepCollectionEquality().hash(subResourceIds),type,const DeepCollectionEquality().hash(userAccesses),const DeepCollectionEquality().hash(teamAccesses),public,administratorsOnly,system);
+
+@override
+String toString() {
+  return 'ResourceControlInfo(id: $id, resourceId: $resourceId, subResourceIds: $subResourceIds, type: $type, userAccesses: $userAccesses, teamAccesses: $teamAccesses, public: $public, administratorsOnly: $administratorsOnly, system: $system)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ResourceControlInfoCopyWith<$Res>  {
+  factory $ResourceControlInfoCopyWith(ResourceControlInfo value, $Res Function(ResourceControlInfo) _then) = _$ResourceControlInfoCopyWithImpl;
+@useResult
+$Res call({
+ int id, String resourceId, List<String> subResourceIds, int type, List<dynamic> userAccesses, List<dynamic> teamAccesses, bool public, bool administratorsOnly, bool system
+});
+
+
+
+
+}
+/// @nodoc
+class _$ResourceControlInfoCopyWithImpl<$Res>
+    implements $ResourceControlInfoCopyWith<$Res> {
+  _$ResourceControlInfoCopyWithImpl(this._self, this._then);
+
+  final ResourceControlInfo _self;
+  final $Res Function(ResourceControlInfo) _then;
+
+/// Create a copy of ResourceControlInfo
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? resourceId = null,Object? subResourceIds = null,Object? type = null,Object? userAccesses = null,Object? teamAccesses = null,Object? public = null,Object? administratorsOnly = null,Object? system = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,resourceId: null == resourceId ? _self.resourceId : resourceId // ignore: cast_nullable_to_non_nullable
+as String,subResourceIds: null == subResourceIds ? _self.subResourceIds : subResourceIds // ignore: cast_nullable_to_non_nullable
+as List<String>,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as int,userAccesses: null == userAccesses ? _self.userAccesses : userAccesses // ignore: cast_nullable_to_non_nullable
+as List<dynamic>,teamAccesses: null == teamAccesses ? _self.teamAccesses : teamAccesses // ignore: cast_nullable_to_non_nullable
+as List<dynamic>,public: null == public ? _self.public : public // ignore: cast_nullable_to_non_nullable
+as bool,administratorsOnly: null == administratorsOnly ? _self.administratorsOnly : administratorsOnly // ignore: cast_nullable_to_non_nullable
+as bool,system: null == system ? _self.system : system // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ResourceControlInfo].
+extension ResourceControlInfoPatterns on ResourceControlInfo {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ResourceControlInfo value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ResourceControlInfo() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ResourceControlInfo value)  $default,){
+final _that = this;
+switch (_that) {
+case _ResourceControlInfo():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ResourceControlInfo value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ResourceControlInfo() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String resourceId,  List<String> subResourceIds,  int type,  List<dynamic> userAccesses,  List<dynamic> teamAccesses,  bool public,  bool administratorsOnly,  bool system)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ResourceControlInfo() when $default != null:
+return $default(_that.id,_that.resourceId,_that.subResourceIds,_that.type,_that.userAccesses,_that.teamAccesses,_that.public,_that.administratorsOnly,_that.system);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String resourceId,  List<String> subResourceIds,  int type,  List<dynamic> userAccesses,  List<dynamic> teamAccesses,  bool public,  bool administratorsOnly,  bool system)  $default,) {final _that = this;
+switch (_that) {
+case _ResourceControlInfo():
+return $default(_that.id,_that.resourceId,_that.subResourceIds,_that.type,_that.userAccesses,_that.teamAccesses,_that.public,_that.administratorsOnly,_that.system);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String resourceId,  List<String> subResourceIds,  int type,  List<dynamic> userAccesses,  List<dynamic> teamAccesses,  bool public,  bool administratorsOnly,  bool system)?  $default,) {final _that = this;
+switch (_that) {
+case _ResourceControlInfo() when $default != null:
+return $default(_that.id,_that.resourceId,_that.subResourceIds,_that.type,_that.userAccesses,_that.teamAccesses,_that.public,_that.administratorsOnly,_that.system);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.pascal)
+class _ResourceControlInfo implements ResourceControlInfo {
+  const _ResourceControlInfo({required this.id, required this.resourceId, required final  List<String> subResourceIds, required this.type, required final  List<dynamic> userAccesses, required final  List<dynamic> teamAccesses, required this.public, required this.administratorsOnly, required this.system}): _subResourceIds = subResourceIds,_userAccesses = userAccesses,_teamAccesses = teamAccesses;
+  factory _ResourceControlInfo.fromJson(Map<String, dynamic> json) => _$ResourceControlInfoFromJson(json);
+
+@override final  int id;
+@override final  String resourceId;
+ final  List<String> _subResourceIds;
+@override List<String> get subResourceIds {
+  if (_subResourceIds is EqualUnmodifiableListView) return _subResourceIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_subResourceIds);
+}
+
+@override final  int type;
+ final  List<dynamic> _userAccesses;
+@override List<dynamic> get userAccesses {
+  if (_userAccesses is EqualUnmodifiableListView) return _userAccesses;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_userAccesses);
+}
+
+ final  List<dynamic> _teamAccesses;
+@override List<dynamic> get teamAccesses {
+  if (_teamAccesses is EqualUnmodifiableListView) return _teamAccesses;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_teamAccesses);
+}
+
+@override final  bool public;
+@override final  bool administratorsOnly;
+@override final  bool system;
+
+/// Create a copy of ResourceControlInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ResourceControlInfoCopyWith<_ResourceControlInfo> get copyWith => __$ResourceControlInfoCopyWithImpl<_ResourceControlInfo>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ResourceControlInfoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ResourceControlInfo&&(identical(other.id, id) || other.id == id)&&(identical(other.resourceId, resourceId) || other.resourceId == resourceId)&&const DeepCollectionEquality().equals(other._subResourceIds, _subResourceIds)&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other._userAccesses, _userAccesses)&&const DeepCollectionEquality().equals(other._teamAccesses, _teamAccesses)&&(identical(other.public, public) || other.public == public)&&(identical(other.administratorsOnly, administratorsOnly) || other.administratorsOnly == administratorsOnly)&&(identical(other.system, system) || other.system == system));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,resourceId,const DeepCollectionEquality().hash(_subResourceIds),type,const DeepCollectionEquality().hash(_userAccesses),const DeepCollectionEquality().hash(_teamAccesses),public,administratorsOnly,system);
+
+@override
+String toString() {
+  return 'ResourceControlInfo(id: $id, resourceId: $resourceId, subResourceIds: $subResourceIds, type: $type, userAccesses: $userAccesses, teamAccesses: $teamAccesses, public: $public, administratorsOnly: $administratorsOnly, system: $system)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ResourceControlInfoCopyWith<$Res> implements $ResourceControlInfoCopyWith<$Res> {
+  factory _$ResourceControlInfoCopyWith(_ResourceControlInfo value, $Res Function(_ResourceControlInfo) _then) = __$ResourceControlInfoCopyWithImpl;
+@override @useResult
+$Res call({
+ int id, String resourceId, List<String> subResourceIds, int type, List<dynamic> userAccesses, List<dynamic> teamAccesses, bool public, bool administratorsOnly, bool system
+});
+
+
+
+
+}
+/// @nodoc
+class __$ResourceControlInfoCopyWithImpl<$Res>
+    implements _$ResourceControlInfoCopyWith<$Res> {
+  __$ResourceControlInfoCopyWithImpl(this._self, this._then);
+
+  final _ResourceControlInfo _self;
+  final $Res Function(_ResourceControlInfo) _then;
+
+/// Create a copy of ResourceControlInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? resourceId = null,Object? subResourceIds = null,Object? type = null,Object? userAccesses = null,Object? teamAccesses = null,Object? public = null,Object? administratorsOnly = null,Object? system = null,}) {
+  return _then(_ResourceControlInfo(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,resourceId: null == resourceId ? _self.resourceId : resourceId // ignore: cast_nullable_to_non_nullable
+as String,subResourceIds: null == subResourceIds ? _self._subResourceIds : subResourceIds // ignore: cast_nullable_to_non_nullable
+as List<String>,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as int,userAccesses: null == userAccesses ? _self._userAccesses : userAccesses // ignore: cast_nullable_to_non_nullable
+as List<dynamic>,teamAccesses: null == teamAccesses ? _self._teamAccesses : teamAccesses // ignore: cast_nullable_to_non_nullable
+as List<dynamic>,public: null == public ? _self.public : public // ignore: cast_nullable_to_non_nullable
+as bool,administratorsOnly: null == administratorsOnly ? _self.administratorsOnly : administratorsOnly // ignore: cast_nullable_to_non_nullable
+as bool,system: null == system ? _self.system : system // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/data/services/api/models/volume/volume_api_model.g.dart
+++ b/lib/data/services/api/models/volume/volume_api_model.g.dart
@@ -1,0 +1,76 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'volume_api_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_VolumeApiModel _$VolumeApiModelFromJson(Map<String, dynamic> json) =>
+    _VolumeApiModel(
+      createdAt: json['CreatedAt'] as String,
+      driver: json['Driver'] as String,
+      labels: (json['Labels'] as Map<String, dynamic>?)?.map(
+        (k, e) => MapEntry(k, e as String),
+      ),
+      mountpoint: json['Mountpoint'] as String,
+      name: json['Name'] as String,
+      options: json['Options'] as Map<String, dynamic>?,
+      resourceID: json['ResourceID'] as String?,
+      scope: json['Scope'] as String,
+      portainer: json['Portainer'] == null
+          ? null
+          : PortainerInfo.fromJson(json['Portainer'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$VolumeApiModelToJson(_VolumeApiModel instance) =>
+    <String, dynamic>{
+      'CreatedAt': instance.createdAt,
+      'Driver': instance.driver,
+      'Labels': instance.labels,
+      'Mountpoint': instance.mountpoint,
+      'Name': instance.name,
+      'Options': instance.options,
+      'ResourceID': instance.resourceID,
+      'Scope': instance.scope,
+      'Portainer': instance.portainer,
+    };
+
+_PortainerInfo _$PortainerInfoFromJson(Map<String, dynamic> json) =>
+    _PortainerInfo(
+      resourceControl: ResourceControlInfo.fromJson(
+        json['ResourceControl'] as Map<String, dynamic>,
+      ),
+    );
+
+Map<String, dynamic> _$PortainerInfoToJson(_PortainerInfo instance) =>
+    <String, dynamic>{'ResourceControl': instance.resourceControl};
+
+_ResourceControlInfo _$ResourceControlInfoFromJson(Map<String, dynamic> json) =>
+    _ResourceControlInfo(
+      id: (json['Id'] as num).toInt(),
+      resourceId: json['ResourceId'] as String,
+      subResourceIds: (json['SubResourceIds'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      type: (json['Type'] as num).toInt(),
+      userAccesses: json['UserAccesses'] as List<dynamic>,
+      teamAccesses: json['TeamAccesses'] as List<dynamic>,
+      public: json['Public'] as bool,
+      administratorsOnly: json['AdministratorsOnly'] as bool,
+      system: json['System'] as bool,
+    );
+
+Map<String, dynamic> _$ResourceControlInfoToJson(
+  _ResourceControlInfo instance,
+) => <String, dynamic>{
+  'Id': instance.id,
+  'ResourceId': instance.resourceId,
+  'SubResourceIds': instance.subResourceIds,
+  'Type': instance.type,
+  'UserAccesses': instance.userAccesses,
+  'TeamAccesses': instance.teamAccesses,
+  'Public': instance.public,
+  'AdministratorsOnly': instance.administratorsOnly,
+  'System': instance.system,
+};

--- a/lib/domain/models/volume/volume.dart
+++ b/lib/domain/models/volume/volume.dart
@@ -1,0 +1,53 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'volume.freezed.dart';
+part 'volume.g.dart';
+
+@freezed
+abstract class Volume with _$Volume {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
+  const factory Volume({
+    required String createdAt,
+    required String driver,
+    Map<String, String>? labels,
+    String? stack,
+    required String mountpoint,
+    required String name,
+    String? resourceID,
+    required String scope,
+    PortainerInfo? portainer,
+  }) = _Volume;
+
+  factory Volume.fromJson(Map<String, dynamic> json) =>
+      _$VolumeFromJson(json);
+}
+
+@freezed
+abstract class PortainerInfo with _$PortainerInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
+  const factory PortainerInfo({
+    required ResourceControlInfo resourceControl,
+  }) = _PortainerInfo;
+
+  factory PortainerInfo.fromJson(Map<String, dynamic> json) =>
+      _$PortainerInfoFromJson(json);
+}
+
+@freezed
+abstract class ResourceControlInfo with _$ResourceControlInfo {
+  @JsonSerializable(fieldRename: FieldRename.pascal)
+  const factory ResourceControlInfo({
+    required int id,
+    required String resourceId,
+    required List<String> subResourceIds,
+    required int type,
+    required List<dynamic> userAccesses,
+    required List<dynamic> teamAccesses,
+    required bool public,
+    required bool administratorsOnly,
+    required bool system,
+  }) = _ResourceControlInfo;
+
+  factory ResourceControlInfo.fromJson(Map<String, dynamic> json) =>
+      _$ResourceControlInfoFromJson(json);
+}

--- a/lib/domain/models/volume/volume.freezed.dart
+++ b/lib/domain/models/volume/volume.freezed.dart
@@ -1,0 +1,919 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'volume.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Volume {
+
+ String get createdAt; String get driver; Map<String, String>? get labels; String? get stack; String get mountpoint; String get name; String? get resourceID; String get scope; PortainerInfo? get portainer;
+/// Create a copy of Volume
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VolumeCopyWith<Volume> get copyWith => _$VolumeCopyWithImpl<Volume>(this as Volume, _$identity);
+
+  /// Serializes this Volume to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Volume&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.driver, driver) || other.driver == driver)&&const DeepCollectionEquality().equals(other.labels, labels)&&(identical(other.stack, stack) || other.stack == stack)&&(identical(other.mountpoint, mountpoint) || other.mountpoint == mountpoint)&&(identical(other.name, name) || other.name == name)&&(identical(other.resourceID, resourceID) || other.resourceID == resourceID)&&(identical(other.scope, scope) || other.scope == scope)&&(identical(other.portainer, portainer) || other.portainer == portainer));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,createdAt,driver,const DeepCollectionEquality().hash(labels),stack,mountpoint,name,resourceID,scope,portainer);
+
+@override
+String toString() {
+  return 'Volume(createdAt: $createdAt, driver: $driver, labels: $labels, stack: $stack, mountpoint: $mountpoint, name: $name, resourceID: $resourceID, scope: $scope, portainer: $portainer)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $VolumeCopyWith<$Res>  {
+  factory $VolumeCopyWith(Volume value, $Res Function(Volume) _then) = _$VolumeCopyWithImpl;
+@useResult
+$Res call({
+ String createdAt, String driver, Map<String, String>? labels, String? stack, String mountpoint, String name, String? resourceID, String scope, PortainerInfo? portainer
+});
+
+
+$PortainerInfoCopyWith<$Res>? get portainer;
+
+}
+/// @nodoc
+class _$VolumeCopyWithImpl<$Res>
+    implements $VolumeCopyWith<$Res> {
+  _$VolumeCopyWithImpl(this._self, this._then);
+
+  final Volume _self;
+  final $Res Function(Volume) _then;
+
+/// Create a copy of Volume
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? createdAt = null,Object? driver = null,Object? labels = freezed,Object? stack = freezed,Object? mountpoint = null,Object? name = null,Object? resourceID = freezed,Object? scope = null,Object? portainer = freezed,}) {
+  return _then(_self.copyWith(
+createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as String,driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
+as String,labels: freezed == labels ? _self.labels : labels // ignore: cast_nullable_to_non_nullable
+as Map<String, String>?,stack: freezed == stack ? _self.stack : stack // ignore: cast_nullable_to_non_nullable
+as String?,mountpoint: null == mountpoint ? _self.mountpoint : mountpoint // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,resourceID: freezed == resourceID ? _self.resourceID : resourceID // ignore: cast_nullable_to_non_nullable
+as String?,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
+as String,portainer: freezed == portainer ? _self.portainer : portainer // ignore: cast_nullable_to_non_nullable
+as PortainerInfo?,
+  ));
+}
+/// Create a copy of Volume
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PortainerInfoCopyWith<$Res>? get portainer {
+    if (_self.portainer == null) {
+    return null;
+  }
+
+  return $PortainerInfoCopyWith<$Res>(_self.portainer!, (value) {
+    return _then(_self.copyWith(portainer: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [Volume].
+extension VolumePatterns on Volume {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Volume value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Volume() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Volume value)  $default,){
+final _that = this;
+switch (_that) {
+case _Volume():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Volume value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Volume() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String createdAt,  String driver,  Map<String, String>? labels,  String? stack,  String mountpoint,  String name,  String? resourceID,  String scope,  PortainerInfo? portainer)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Volume() when $default != null:
+return $default(_that.createdAt,_that.driver,_that.labels,_that.stack,_that.mountpoint,_that.name,_that.resourceID,_that.scope,_that.portainer);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String createdAt,  String driver,  Map<String, String>? labels,  String? stack,  String mountpoint,  String name,  String? resourceID,  String scope,  PortainerInfo? portainer)  $default,) {final _that = this;
+switch (_that) {
+case _Volume():
+return $default(_that.createdAt,_that.driver,_that.labels,_that.stack,_that.mountpoint,_that.name,_that.resourceID,_that.scope,_that.portainer);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String createdAt,  String driver,  Map<String, String>? labels,  String? stack,  String mountpoint,  String name,  String? resourceID,  String scope,  PortainerInfo? portainer)?  $default,) {final _that = this;
+switch (_that) {
+case _Volume() when $default != null:
+return $default(_that.createdAt,_that.driver,_that.labels,_that.stack,_that.mountpoint,_that.name,_that.resourceID,_that.scope,_that.portainer);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.pascal)
+class _Volume implements Volume {
+  const _Volume({required this.createdAt, required this.driver, final  Map<String, String>? labels, this.stack, required this.mountpoint, required this.name, this.resourceID, required this.scope, this.portainer}): _labels = labels;
+  factory _Volume.fromJson(Map<String, dynamic> json) => _$VolumeFromJson(json);
+
+@override final  String createdAt;
+@override final  String driver;
+ final  Map<String, String>? _labels;
+@override Map<String, String>? get labels {
+  final value = _labels;
+  if (value == null) return null;
+  if (_labels is EqualUnmodifiableMapView) return _labels;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+@override final  String? stack;
+@override final  String mountpoint;
+@override final  String name;
+@override final  String? resourceID;
+@override final  String scope;
+@override final  PortainerInfo? portainer;
+
+/// Create a copy of Volume
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VolumeCopyWith<_Volume> get copyWith => __$VolumeCopyWithImpl<_Volume>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$VolumeToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Volume&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.driver, driver) || other.driver == driver)&&const DeepCollectionEquality().equals(other._labels, _labels)&&(identical(other.stack, stack) || other.stack == stack)&&(identical(other.mountpoint, mountpoint) || other.mountpoint == mountpoint)&&(identical(other.name, name) || other.name == name)&&(identical(other.resourceID, resourceID) || other.resourceID == resourceID)&&(identical(other.scope, scope) || other.scope == scope)&&(identical(other.portainer, portainer) || other.portainer == portainer));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,createdAt,driver,const DeepCollectionEquality().hash(_labels),stack,mountpoint,name,resourceID,scope,portainer);
+
+@override
+String toString() {
+  return 'Volume(createdAt: $createdAt, driver: $driver, labels: $labels, stack: $stack, mountpoint: $mountpoint, name: $name, resourceID: $resourceID, scope: $scope, portainer: $portainer)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$VolumeCopyWith<$Res> implements $VolumeCopyWith<$Res> {
+  factory _$VolumeCopyWith(_Volume value, $Res Function(_Volume) _then) = __$VolumeCopyWithImpl;
+@override @useResult
+$Res call({
+ String createdAt, String driver, Map<String, String>? labels, String? stack, String mountpoint, String name, String? resourceID, String scope, PortainerInfo? portainer
+});
+
+
+@override $PortainerInfoCopyWith<$Res>? get portainer;
+
+}
+/// @nodoc
+class __$VolumeCopyWithImpl<$Res>
+    implements _$VolumeCopyWith<$Res> {
+  __$VolumeCopyWithImpl(this._self, this._then);
+
+  final _Volume _self;
+  final $Res Function(_Volume) _then;
+
+/// Create a copy of Volume
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? createdAt = null,Object? driver = null,Object? labels = freezed,Object? stack = freezed,Object? mountpoint = null,Object? name = null,Object? resourceID = freezed,Object? scope = null,Object? portainer = freezed,}) {
+  return _then(_Volume(
+createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as String,driver: null == driver ? _self.driver : driver // ignore: cast_nullable_to_non_nullable
+as String,labels: freezed == labels ? _self._labels : labels // ignore: cast_nullable_to_non_nullable
+as Map<String, String>?,stack: freezed == stack ? _self.stack : stack // ignore: cast_nullable_to_non_nullable
+as String?,mountpoint: null == mountpoint ? _self.mountpoint : mountpoint // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,resourceID: freezed == resourceID ? _self.resourceID : resourceID // ignore: cast_nullable_to_non_nullable
+as String?,scope: null == scope ? _self.scope : scope // ignore: cast_nullable_to_non_nullable
+as String,portainer: freezed == portainer ? _self.portainer : portainer // ignore: cast_nullable_to_non_nullable
+as PortainerInfo?,
+  ));
+}
+
+/// Create a copy of Volume
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PortainerInfoCopyWith<$Res>? get portainer {
+    if (_self.portainer == null) {
+    return null;
+  }
+
+  return $PortainerInfoCopyWith<$Res>(_self.portainer!, (value) {
+    return _then(_self.copyWith(portainer: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$PortainerInfo {
+
+ ResourceControlInfo get resourceControl;
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PortainerInfoCopyWith<PortainerInfo> get copyWith => _$PortainerInfoCopyWithImpl<PortainerInfo>(this as PortainerInfo, _$identity);
+
+  /// Serializes this PortainerInfo to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PortainerInfo&&(identical(other.resourceControl, resourceControl) || other.resourceControl == resourceControl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,resourceControl);
+
+@override
+String toString() {
+  return 'PortainerInfo(resourceControl: $resourceControl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PortainerInfoCopyWith<$Res>  {
+  factory $PortainerInfoCopyWith(PortainerInfo value, $Res Function(PortainerInfo) _then) = _$PortainerInfoCopyWithImpl;
+@useResult
+$Res call({
+ ResourceControlInfo resourceControl
+});
+
+
+$ResourceControlInfoCopyWith<$Res> get resourceControl;
+
+}
+/// @nodoc
+class _$PortainerInfoCopyWithImpl<$Res>
+    implements $PortainerInfoCopyWith<$Res> {
+  _$PortainerInfoCopyWithImpl(this._self, this._then);
+
+  final PortainerInfo _self;
+  final $Res Function(PortainerInfo) _then;
+
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? resourceControl = null,}) {
+  return _then(_self.copyWith(
+resourceControl: null == resourceControl ? _self.resourceControl : resourceControl // ignore: cast_nullable_to_non_nullable
+as ResourceControlInfo,
+  ));
+}
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ResourceControlInfoCopyWith<$Res> get resourceControl {
+  
+  return $ResourceControlInfoCopyWith<$Res>(_self.resourceControl, (value) {
+    return _then(_self.copyWith(resourceControl: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [PortainerInfo].
+extension PortainerInfoPatterns on PortainerInfo {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PortainerInfo value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PortainerInfo() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PortainerInfo value)  $default,){
+final _that = this;
+switch (_that) {
+case _PortainerInfo():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PortainerInfo value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PortainerInfo() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( ResourceControlInfo resourceControl)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PortainerInfo() when $default != null:
+return $default(_that.resourceControl);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( ResourceControlInfo resourceControl)  $default,) {final _that = this;
+switch (_that) {
+case _PortainerInfo():
+return $default(_that.resourceControl);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( ResourceControlInfo resourceControl)?  $default,) {final _that = this;
+switch (_that) {
+case _PortainerInfo() when $default != null:
+return $default(_that.resourceControl);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.pascal)
+class _PortainerInfo implements PortainerInfo {
+  const _PortainerInfo({required this.resourceControl});
+  factory _PortainerInfo.fromJson(Map<String, dynamic> json) => _$PortainerInfoFromJson(json);
+
+@override final  ResourceControlInfo resourceControl;
+
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PortainerInfoCopyWith<_PortainerInfo> get copyWith => __$PortainerInfoCopyWithImpl<_PortainerInfo>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PortainerInfoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PortainerInfo&&(identical(other.resourceControl, resourceControl) || other.resourceControl == resourceControl));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,resourceControl);
+
+@override
+String toString() {
+  return 'PortainerInfo(resourceControl: $resourceControl)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PortainerInfoCopyWith<$Res> implements $PortainerInfoCopyWith<$Res> {
+  factory _$PortainerInfoCopyWith(_PortainerInfo value, $Res Function(_PortainerInfo) _then) = __$PortainerInfoCopyWithImpl;
+@override @useResult
+$Res call({
+ ResourceControlInfo resourceControl
+});
+
+
+@override $ResourceControlInfoCopyWith<$Res> get resourceControl;
+
+}
+/// @nodoc
+class __$PortainerInfoCopyWithImpl<$Res>
+    implements _$PortainerInfoCopyWith<$Res> {
+  __$PortainerInfoCopyWithImpl(this._self, this._then);
+
+  final _PortainerInfo _self;
+  final $Res Function(_PortainerInfo) _then;
+
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? resourceControl = null,}) {
+  return _then(_PortainerInfo(
+resourceControl: null == resourceControl ? _self.resourceControl : resourceControl // ignore: cast_nullable_to_non_nullable
+as ResourceControlInfo,
+  ));
+}
+
+/// Create a copy of PortainerInfo
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ResourceControlInfoCopyWith<$Res> get resourceControl {
+  
+  return $ResourceControlInfoCopyWith<$Res>(_self.resourceControl, (value) {
+    return _then(_self.copyWith(resourceControl: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$ResourceControlInfo {
+
+ int get id; String get resourceId; List<String> get subResourceIds; int get type; List<dynamic> get userAccesses; List<dynamic> get teamAccesses; bool get public; bool get administratorsOnly; bool get system;
+/// Create a copy of ResourceControlInfo
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ResourceControlInfoCopyWith<ResourceControlInfo> get copyWith => _$ResourceControlInfoCopyWithImpl<ResourceControlInfo>(this as ResourceControlInfo, _$identity);
+
+  /// Serializes this ResourceControlInfo to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ResourceControlInfo&&(identical(other.id, id) || other.id == id)&&(identical(other.resourceId, resourceId) || other.resourceId == resourceId)&&const DeepCollectionEquality().equals(other.subResourceIds, subResourceIds)&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other.userAccesses, userAccesses)&&const DeepCollectionEquality().equals(other.teamAccesses, teamAccesses)&&(identical(other.public, public) || other.public == public)&&(identical(other.administratorsOnly, administratorsOnly) || other.administratorsOnly == administratorsOnly)&&(identical(other.system, system) || other.system == system));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,resourceId,const DeepCollectionEquality().hash(subResourceIds),type,const DeepCollectionEquality().hash(userAccesses),const DeepCollectionEquality().hash(teamAccesses),public,administratorsOnly,system);
+
+@override
+String toString() {
+  return 'ResourceControlInfo(id: $id, resourceId: $resourceId, subResourceIds: $subResourceIds, type: $type, userAccesses: $userAccesses, teamAccesses: $teamAccesses, public: $public, administratorsOnly: $administratorsOnly, system: $system)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ResourceControlInfoCopyWith<$Res>  {
+  factory $ResourceControlInfoCopyWith(ResourceControlInfo value, $Res Function(ResourceControlInfo) _then) = _$ResourceControlInfoCopyWithImpl;
+@useResult
+$Res call({
+ int id, String resourceId, List<String> subResourceIds, int type, List<dynamic> userAccesses, List<dynamic> teamAccesses, bool public, bool administratorsOnly, bool system
+});
+
+
+
+
+}
+/// @nodoc
+class _$ResourceControlInfoCopyWithImpl<$Res>
+    implements $ResourceControlInfoCopyWith<$Res> {
+  _$ResourceControlInfoCopyWithImpl(this._self, this._then);
+
+  final ResourceControlInfo _self;
+  final $Res Function(ResourceControlInfo) _then;
+
+/// Create a copy of ResourceControlInfo
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? resourceId = null,Object? subResourceIds = null,Object? type = null,Object? userAccesses = null,Object? teamAccesses = null,Object? public = null,Object? administratorsOnly = null,Object? system = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,resourceId: null == resourceId ? _self.resourceId : resourceId // ignore: cast_nullable_to_non_nullable
+as String,subResourceIds: null == subResourceIds ? _self.subResourceIds : subResourceIds // ignore: cast_nullable_to_non_nullable
+as List<String>,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as int,userAccesses: null == userAccesses ? _self.userAccesses : userAccesses // ignore: cast_nullable_to_non_nullable
+as List<dynamic>,teamAccesses: null == teamAccesses ? _self.teamAccesses : teamAccesses // ignore: cast_nullable_to_non_nullable
+as List<dynamic>,public: null == public ? _self.public : public // ignore: cast_nullable_to_non_nullable
+as bool,administratorsOnly: null == administratorsOnly ? _self.administratorsOnly : administratorsOnly // ignore: cast_nullable_to_non_nullable
+as bool,system: null == system ? _self.system : system // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ResourceControlInfo].
+extension ResourceControlInfoPatterns on ResourceControlInfo {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ResourceControlInfo value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ResourceControlInfo() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ResourceControlInfo value)  $default,){
+final _that = this;
+switch (_that) {
+case _ResourceControlInfo():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ResourceControlInfo value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ResourceControlInfo() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String resourceId,  List<String> subResourceIds,  int type,  List<dynamic> userAccesses,  List<dynamic> teamAccesses,  bool public,  bool administratorsOnly,  bool system)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ResourceControlInfo() when $default != null:
+return $default(_that.id,_that.resourceId,_that.subResourceIds,_that.type,_that.userAccesses,_that.teamAccesses,_that.public,_that.administratorsOnly,_that.system);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String resourceId,  List<String> subResourceIds,  int type,  List<dynamic> userAccesses,  List<dynamic> teamAccesses,  bool public,  bool administratorsOnly,  bool system)  $default,) {final _that = this;
+switch (_that) {
+case _ResourceControlInfo():
+return $default(_that.id,_that.resourceId,_that.subResourceIds,_that.type,_that.userAccesses,_that.teamAccesses,_that.public,_that.administratorsOnly,_that.system);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String resourceId,  List<String> subResourceIds,  int type,  List<dynamic> userAccesses,  List<dynamic> teamAccesses,  bool public,  bool administratorsOnly,  bool system)?  $default,) {final _that = this;
+switch (_that) {
+case _ResourceControlInfo() when $default != null:
+return $default(_that.id,_that.resourceId,_that.subResourceIds,_that.type,_that.userAccesses,_that.teamAccesses,_that.public,_that.administratorsOnly,_that.system);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.pascal)
+class _ResourceControlInfo implements ResourceControlInfo {
+  const _ResourceControlInfo({required this.id, required this.resourceId, required final  List<String> subResourceIds, required this.type, required final  List<dynamic> userAccesses, required final  List<dynamic> teamAccesses, required this.public, required this.administratorsOnly, required this.system}): _subResourceIds = subResourceIds,_userAccesses = userAccesses,_teamAccesses = teamAccesses;
+  factory _ResourceControlInfo.fromJson(Map<String, dynamic> json) => _$ResourceControlInfoFromJson(json);
+
+@override final  int id;
+@override final  String resourceId;
+ final  List<String> _subResourceIds;
+@override List<String> get subResourceIds {
+  if (_subResourceIds is EqualUnmodifiableListView) return _subResourceIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_subResourceIds);
+}
+
+@override final  int type;
+ final  List<dynamic> _userAccesses;
+@override List<dynamic> get userAccesses {
+  if (_userAccesses is EqualUnmodifiableListView) return _userAccesses;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_userAccesses);
+}
+
+ final  List<dynamic> _teamAccesses;
+@override List<dynamic> get teamAccesses {
+  if (_teamAccesses is EqualUnmodifiableListView) return _teamAccesses;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_teamAccesses);
+}
+
+@override final  bool public;
+@override final  bool administratorsOnly;
+@override final  bool system;
+
+/// Create a copy of ResourceControlInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ResourceControlInfoCopyWith<_ResourceControlInfo> get copyWith => __$ResourceControlInfoCopyWithImpl<_ResourceControlInfo>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ResourceControlInfoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ResourceControlInfo&&(identical(other.id, id) || other.id == id)&&(identical(other.resourceId, resourceId) || other.resourceId == resourceId)&&const DeepCollectionEquality().equals(other._subResourceIds, _subResourceIds)&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other._userAccesses, _userAccesses)&&const DeepCollectionEquality().equals(other._teamAccesses, _teamAccesses)&&(identical(other.public, public) || other.public == public)&&(identical(other.administratorsOnly, administratorsOnly) || other.administratorsOnly == administratorsOnly)&&(identical(other.system, system) || other.system == system));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,resourceId,const DeepCollectionEquality().hash(_subResourceIds),type,const DeepCollectionEquality().hash(_userAccesses),const DeepCollectionEquality().hash(_teamAccesses),public,administratorsOnly,system);
+
+@override
+String toString() {
+  return 'ResourceControlInfo(id: $id, resourceId: $resourceId, subResourceIds: $subResourceIds, type: $type, userAccesses: $userAccesses, teamAccesses: $teamAccesses, public: $public, administratorsOnly: $administratorsOnly, system: $system)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ResourceControlInfoCopyWith<$Res> implements $ResourceControlInfoCopyWith<$Res> {
+  factory _$ResourceControlInfoCopyWith(_ResourceControlInfo value, $Res Function(_ResourceControlInfo) _then) = __$ResourceControlInfoCopyWithImpl;
+@override @useResult
+$Res call({
+ int id, String resourceId, List<String> subResourceIds, int type, List<dynamic> userAccesses, List<dynamic> teamAccesses, bool public, bool administratorsOnly, bool system
+});
+
+
+
+
+}
+/// @nodoc
+class __$ResourceControlInfoCopyWithImpl<$Res>
+    implements _$ResourceControlInfoCopyWith<$Res> {
+  __$ResourceControlInfoCopyWithImpl(this._self, this._then);
+
+  final _ResourceControlInfo _self;
+  final $Res Function(_ResourceControlInfo) _then;
+
+/// Create a copy of ResourceControlInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? resourceId = null,Object? subResourceIds = null,Object? type = null,Object? userAccesses = null,Object? teamAccesses = null,Object? public = null,Object? administratorsOnly = null,Object? system = null,}) {
+  return _then(_ResourceControlInfo(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as int,resourceId: null == resourceId ? _self.resourceId : resourceId // ignore: cast_nullable_to_non_nullable
+as String,subResourceIds: null == subResourceIds ? _self._subResourceIds : subResourceIds // ignore: cast_nullable_to_non_nullable
+as List<String>,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as int,userAccesses: null == userAccesses ? _self._userAccesses : userAccesses // ignore: cast_nullable_to_non_nullable
+as List<dynamic>,teamAccesses: null == teamAccesses ? _self._teamAccesses : teamAccesses // ignore: cast_nullable_to_non_nullable
+as List<dynamic>,public: null == public ? _self.public : public // ignore: cast_nullable_to_non_nullable
+as bool,administratorsOnly: null == administratorsOnly ? _self.administratorsOnly : administratorsOnly // ignore: cast_nullable_to_non_nullable
+as bool,system: null == system ? _self.system : system // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/domain/models/volume/volume.g.dart
+++ b/lib/domain/models/volume/volume.g.dart
@@ -1,0 +1,74 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'volume.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_Volume _$VolumeFromJson(Map<String, dynamic> json) => _Volume(
+  createdAt: json['CreatedAt'] as String,
+  driver: json['Driver'] as String,
+  labels: (json['Labels'] as Map<String, dynamic>?)?.map(
+    (k, e) => MapEntry(k, e as String),
+  ),
+  stack: json['Stack'] as String?,
+  mountpoint: json['Mountpoint'] as String,
+  name: json['Name'] as String,
+  resourceID: json['ResourceID'] as String?,
+  scope: json['Scope'] as String,
+  portainer: json['Portainer'] == null
+      ? null
+      : PortainerInfo.fromJson(json['Portainer'] as Map<String, dynamic>),
+);
+
+Map<String, dynamic> _$VolumeToJson(_Volume instance) => <String, dynamic>{
+  'CreatedAt': instance.createdAt,
+  'Driver': instance.driver,
+  'Labels': instance.labels,
+  'Stack': instance.stack,
+  'Mountpoint': instance.mountpoint,
+  'Name': instance.name,
+  'ResourceID': instance.resourceID,
+  'Scope': instance.scope,
+  'Portainer': instance.portainer,
+};
+
+_PortainerInfo _$PortainerInfoFromJson(Map<String, dynamic> json) =>
+    _PortainerInfo(
+      resourceControl: ResourceControlInfo.fromJson(
+        json['ResourceControl'] as Map<String, dynamic>,
+      ),
+    );
+
+Map<String, dynamic> _$PortainerInfoToJson(_PortainerInfo instance) =>
+    <String, dynamic>{'ResourceControl': instance.resourceControl};
+
+_ResourceControlInfo _$ResourceControlInfoFromJson(Map<String, dynamic> json) =>
+    _ResourceControlInfo(
+      id: (json['Id'] as num).toInt(),
+      resourceId: json['ResourceId'] as String,
+      subResourceIds: (json['SubResourceIds'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      type: (json['Type'] as num).toInt(),
+      userAccesses: json['UserAccesses'] as List<dynamic>,
+      teamAccesses: json['TeamAccesses'] as List<dynamic>,
+      public: json['Public'] as bool,
+      administratorsOnly: json['AdministratorsOnly'] as bool,
+      system: json['System'] as bool,
+    );
+
+Map<String, dynamic> _$ResourceControlInfoToJson(
+  _ResourceControlInfo instance,
+) => <String, dynamic>{
+  'Id': instance.id,
+  'ResourceId': instance.resourceId,
+  'SubResourceIds': instance.subResourceIds,
+  'Type': instance.type,
+  'UserAccesses': instance.userAccesses,
+  'TeamAccesses': instance.teamAccesses,
+  'Public': instance.public,
+  'AdministratorsOnly': instance.administratorsOnly,
+  'System': instance.system,
+};

--- a/lib/routing/router.dart
+++ b/lib/routing/router.dart
@@ -4,6 +4,9 @@ import 'package:container_monitoring/ui/main_home/widgets/main_home_screen.dart'
 import 'package:container_monitoring/ui/dashboard/widgets/dashboard_screen.dart';
 import 'package:container_monitoring/ui/dashboard/view_models/dashboard_viewmodel.dart';
 import 'package:container_monitoring/ui/user/view_models/user_viewmodel.dart';
+import 'package:container_monitoring/ui/volume/widgets/volumes_screen.dart';
+import 'package:container_monitoring/ui/volume/widgets/volume_screen.dart';
+import 'package:container_monitoring/ui/volume/view_models/volume_viewmodel.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -34,7 +37,10 @@ GoRouter router(AuthRepository authRepository) => GoRouter(
         final homeViewModel = HomeViewModel(
           environmentRepository: context.read(),
         );
-        final userViewModel = UserViewModel(userRepository: context.read());
+        final userViewModel = UserViewModel(
+          userRepository: context.read(),
+          authRepository: context.read(),
+        );
         return MainHomeScreen(
           homeViewModel: homeViewModel,
           userViewModel: userViewModel,
@@ -57,6 +63,47 @@ GoRouter router(AuthRepository authRepository) => GoRouter(
         
         return DashboardScreen(viewModel: viewModel);
       },
+      routes: [
+        GoRoute(
+          name: 'volumes',
+          path: 'volumes',
+          builder: (context, state) {
+            final idParam = state.pathParameters['id'];
+            final id = int.tryParse(idParam ?? '');
+            if (id == null) {
+              return const SizedBox.shrink();
+            }
+
+            final viewModel = VolumeViewmodel(volumeRepository: context.read());
+            viewModel.loadVolumes.execute(id);
+            
+            return VolumesScreen(viewModel: viewModel, environmentId: id);
+          },
+          routes: [
+            GoRoute(
+              name: 'volume',
+              path: ':volumeName',
+              builder: (context, state) {
+                final idParam = state.pathParameters['id'];
+                final volumeName = state.pathParameters['volumeName'];
+                final id = int.tryParse(idParam ?? '');
+                
+                if (id == null || volumeName == null) {
+                  return const SizedBox.shrink();
+                }
+
+                final viewModel = VolumeViewmodel(volumeRepository: context.read());
+                
+                return VolumeScreen(
+                  viewModel: viewModel,
+                  environmentId: id,
+                  volumeName: volumeName,
+                );
+              },
+            ),
+          ],
+        ),
+      ],
     ),
   ],
 );

--- a/lib/routing/routes.dart
+++ b/lib/routing/routes.dart
@@ -2,4 +2,5 @@ abstract final class Routes {
   static const home = '/';
   static const login = '/login';
   static const dashboard = '/dashboard/:id';
+  static const volumes = '/dashboard/:id/volumes';
 }

--- a/lib/ui/dashboard/widgets/dashboard_screen.dart
+++ b/lib/ui/dashboard/widgets/dashboard_screen.dart
@@ -28,7 +28,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
               icon: const Icon(Icons.arrow_back),
               onPressed: () => context.go(Routes.home),
             ),
-            title: Text(env?.name ?? 'Dashboard'),
+            title: Text('Dashboard'),
           ),
           body: env == null
               ? const Center(child: CircularProgressIndicator())
@@ -60,20 +60,20 @@ class _DashboardScreenState extends State<DashboardScreen> {
                               SizedBox(
                                 width: itemWidth,
                                 child: ActionInfoCard(
-                                  icon: Icons.layers_outlined,
-                                  value: env.stackCount.toString(),
-                                  title: 'Stacks',
+                                  icon: Icons.apps_outlined,
+                                  value: env.containerCount.toString(),
+                                  title: 'Containers',
+                                  subtitle:
+                                      '${env.runningContainerCount} running   ${env.stoppedContainerCount} stopped\n${env.healthyContainerCount} healthy   ${env.unhealthyContainerCount} unhealthy',
                                   onTap: () {},
                                 ),
                               ),
                               SizedBox(
                                 width: itemWidth,
                                 child: ActionInfoCard(
-                                  icon: Icons.apps_outlined,
-                                  value: env.containerCount.toString(),
-                                  title: 'Containers',
-                                  subtitle:
-                                      '${env.runningContainerCount} running   ${env.stoppedContainerCount} stopped\n${env.healthyContainerCount} healthy   ${env.unhealthyContainerCount} unhealthy',
+                                  icon: Icons.layers_outlined,
+                                  value: env.stackCount.toString(),
+                                  title: 'Stacks',
                                   onTap: () {},
                                 ),
                               ),
@@ -89,10 +89,12 @@ class _DashboardScreenState extends State<DashboardScreen> {
                               SizedBox(
                                 width: itemWidth,
                                 child: ActionInfoCard(
-                                  icon: Icons.folder_outlined,
+                                  icon: Icons.storage_outlined,
                                   value: env.volumeCount.toString(),
                                   title: 'Volumes',
-                                  onTap: () {},
+                                  onTap: () => context.go(
+                                    '/dashboard/${env.id}/volumes',
+                                  ),
                                 ),
                               ),
                               SizedBox(
@@ -115,13 +117,4 @@ class _DashboardScreenState extends State<DashboardScreen> {
       },
     );
   }
-}
-
-String _formatMemoryShort(int bytes) {
-  final gb = bytes / 1000 / 1000 / 1000;
-  if (gb >= 1) return '${gb.toStringAsFixed(1)} GB';
-  final mb = bytes / 1000 / 1000;
-  if (mb >= 1) return '${mb.toStringAsFixed(1)} MB';
-  final kb = bytes / 1000;
-  return '${kb.toStringAsFixed(1)} KB';
 }

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -261,8 +261,8 @@ class _PulsingDotState extends State<_PulsingDot>
       builder: (context, child) {
         final lerp = _anim.value;
         final color = Color.lerp(
-          baseColor.withOpacity(0.5),
-          baseColor.withOpacity(1.0),
+          baseColor.withValues(alpha: 0.5),
+          baseColor.withValues(alpha: 1.0),
           lerp,
         )!;
         return Container(

--- a/lib/ui/user/view_models/user_viewmodel.dart
+++ b/lib/ui/user/view_models/user_viewmodel.dart
@@ -4,21 +4,27 @@ import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 
 import 'package:container_monitoring/data/repositories/user/user_repository.dart';
+import 'package:container_monitoring/data/repositories/auth/auth_repository.dart';
 import 'package:container_monitoring/utils/command.dart';
 import 'package:container_monitoring/utils/result.dart';
 
-
 class UserViewModel extends ChangeNotifier {
-  UserViewModel({required UserRepository userRepository})
-    : _userRepository = userRepository {
-      load = Command0(_load)..execute();
-    }
+  UserViewModel({
+    required UserRepository userRepository,
+    required AuthRepository authRepository,
+  }) : _userRepository = userRepository,
+       _authRepository = authRepository {
+    load = Command0(_load)..execute();
+    logout = Command0(_logout);
+  }
 
   final UserRepository _userRepository;
+  final AuthRepository _authRepository;
   final _log = Logger('UserViewModel');
   User _user = User(username: '', role: 0);
 
   late Command0 load;
+  late Command0 logout;
 
   User get user => _user;
 
@@ -32,6 +38,21 @@ class UserViewModel extends ChangeNotifier {
         case Error():
           _log.warning('Failed to load user', result.error);
           return result;
+      }
+      return result;
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<Result<void>> _logout() async {
+    try {
+      _log.info('Logging out user');
+      final result = await _authRepository.logout();
+      if (result is Error<void>) {
+        _log.warning('Logout failed', result.error);
+      } else {
+        _log.info('User logged out successfully');
       }
       return result;
     } finally {

--- a/lib/ui/volume/view_models/volume_viewmodel.dart
+++ b/lib/ui/volume/view_models/volume_viewmodel.dart
@@ -1,0 +1,77 @@
+import 'package:container_monitoring/data/repositories/volume/volume.dart';
+import 'package:container_monitoring/domain/models/volume/volume.dart' as volume_model;
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+import 'package:container_monitoring/utils/command.dart';
+import 'package:container_monitoring/utils/result.dart';
+
+class VolumeViewmodel extends ChangeNotifier {
+  VolumeViewmodel({required VolumeRepository volumeRepository})
+    : _volumeRepository = volumeRepository {
+      loadVolumes = Command1<void, int>(_loadVolumes);
+      loadVolume = Command2<void, int, String>(_loadVolume);
+    }
+
+  final VolumeRepository _volumeRepository;
+  final _log = Logger('VolumeViewmodel');
+  List<volume_model.Volume> _volumes = [];
+  volume_model.Volume? _volume;
+  bool _isLoading = false;
+  bool _hasMoreData = true;
+  int? _currentEnvironmentId;
+
+  late final Command1<void, int> loadVolumes;
+  late final Command2<void, int, String> loadVolume;
+
+  List<volume_model.Volume> get volumes => _volumes;
+  volume_model.Volume? get volume => _volume;
+  bool get isLoading => _isLoading;
+  bool get hasMoreData => _hasMoreData;
+
+  Future<Result<void>> _loadVolumes(int environmentId) async {
+    if (_isLoading) return Result.ok(null);
+    
+    _currentEnvironmentId = environmentId;
+    _hasMoreData = true;
+    _isLoading = true;
+    notifyListeners();
+
+    final result = await _volumeRepository.listVolumesByEnvironment(environmentId);
+    switch (result) {
+      case Ok<List<volume_model.Volume>>():
+        _volumes = result.value;
+        _log.fine('Loaded volumes for environment ID: $environmentId');
+      case Error<List<volume_model.Volume>>():
+        _log.warning('Failed to load volumes for environment ID: $environmentId', result.error);
+    }
+    
+    _isLoading = false;
+    notifyListeners();
+    return result;
+  }
+
+
+  void refreshVolumes() {
+    if (_currentEnvironmentId != null) {
+      loadVolumes.execute(_currentEnvironmentId!);
+    }
+  }
+
+  Future<Result<void>> _loadVolume(int environmentId, String volumeName) async {
+    _isLoading = true;
+    notifyListeners();
+
+    final result = await _volumeRepository.getVolumeByName(environmentId, volumeName);
+    switch (result) {
+      case Ok<volume_model.Volume>():
+        _volume = result.value;
+        _log.fine('Loaded volume for environment ID: $environmentId and volume name: $volumeName');
+      case Error<volume_model.Volume>():
+        _log.warning('Failed to load volume for environment ID: $environmentId and volume name: $volumeName', result.error);
+    }
+    
+    _isLoading = false;
+    notifyListeners();
+    return result;
+  }
+}

--- a/lib/ui/volume/widgets/volume_screen.dart
+++ b/lib/ui/volume/widgets/volume_screen.dart
@@ -1,0 +1,362 @@
+import 'package:flutter/material.dart';
+import 'package:container_monitoring/ui/volume/view_models/volume_viewmodel.dart';
+
+class VolumeScreen extends StatefulWidget {
+  const VolumeScreen({
+    super.key,
+    required this.viewModel,
+    required this.environmentId,
+    required this.volumeName,
+  });
+
+  final VolumeViewmodel viewModel;
+  final int environmentId;
+  final String volumeName;
+
+  @override
+  State<VolumeScreen> createState() => _VolumeScreenState();
+}
+
+class _VolumeScreenState extends State<VolumeScreen> {
+  @override
+  void initState() {
+    super.initState();
+    widget.viewModel.loadVolume.execute(
+      widget.environmentId,
+      widget.volumeName,
+    );
+  }
+
+  String _formatDate(String dateString) {
+    try {
+      final date = DateTime.parse(dateString);
+      return '${date.day}/${date.month}/${date.year} ${date.hour}:${date.minute.toString().padLeft(2, '0')}:${date.second.toString().padLeft(2, '0')}';
+    } catch (e) {
+      return dateString;
+    }
+  }
+
+  void _showRemoveVolumeDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Remove Volume'),
+          content: Text(
+            'Are you sure you want to remove volume "${widget.volumeName}"? This action cannot be undone.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                // TODO: Implement volume removal functionality.
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('TODO: Implement volume removal functionality.'),
+                  ),
+                );
+              },
+              style: FilledButton.styleFrom(
+                backgroundColor: Theme.of(context).colorScheme.error,
+              ),
+              child: const Text('Remove'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _showChangeOwnershipDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Change Ownership'),
+          content: const Text(
+            'TODO: Implement ownership change functionality.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('TODO: Implement ownership change functionality.'),
+                  ),
+                );
+              },
+              child: const Text('Change'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Volume details'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: ListenableBuilder(
+        listenable: widget.viewModel,
+        builder: (context, child) {
+          if (widget.viewModel.isLoading && widget.viewModel.volume == null) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final volume = widget.viewModel.volume;
+          return RefreshIndicator(
+            onRefresh: () async {
+              await widget.viewModel.loadVolume.execute(
+                widget.environmentId,
+                widget.volumeName,
+              );
+            },
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.all(16),
+              child: volume == null
+                  ? SizedBox(
+                      height: MediaQuery.of(context).size.height * 0.6,
+                      child: const Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(Icons.error_outline, size: 64),
+                            SizedBox(height: 16),
+                            Text(
+                              'Volume not found',
+                              style: TextStyle(fontSize: 18),
+                            ),
+                          ],
+                        ),
+                      ),
+                    )
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Volume Details Card
+                        Card(
+                          elevation: 2,
+                          child: Padding(
+                            padding: const EdgeInsets.all(20),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                 Row(
+                                   children: [
+                                     Icon(
+                                       Icons.storage,
+                                       color: Theme.of(
+                                         context,
+                                       ).colorScheme.primary,
+                                       size: 24,
+                                     ),
+                                     const SizedBox(width: 12),
+                                     Expanded(
+                                       child: Text(
+                                         volume.name,
+                                         style: Theme.of(context)
+                                             .textTheme
+                                             .bodyLarge  
+                                             ?.copyWith(
+                                               fontWeight: FontWeight.w600,
+                                             ),
+                                         overflow: TextOverflow.ellipsis,
+                                         maxLines: 1,
+                                       ),
+                                     ),
+                                   ],
+                                 ),
+                                const SizedBox(height: 20),
+                                _buildDetailRow('ID', volume.name),
+                                const Divider(),
+                                _buildDetailRow(
+                                  'Created',
+                                  _formatDate(volume.createdAt),
+                                ),
+                                const Divider(),
+                                _buildDetailRow(
+                                  'Mount path',
+                                  volume.mountpoint,
+                                ),
+                                const Divider(),
+                                _buildDetailRow('Driver', volume.driver),
+                                if (volume.labels != null &&
+                                    volume.labels!.isNotEmpty) ...[
+                                  const Divider(),
+                                  const SizedBox(height: 8),
+                                  Text(
+                                    'Labels',
+                                    style: Theme.of(context).textTheme.bodyLarge
+                                        ?.copyWith(fontWeight: FontWeight.w600),
+                                  ),
+                                  const SizedBox(height: 12),
+                                  ...volume.labels!.entries.map(
+                                    (entry) => Padding(
+                                      padding: const EdgeInsets.only(bottom: 8),
+                                      child: _buildDetailRow(
+                                        entry.key,
+                                        entry.value,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                                const SizedBox(height: 20),
+                                SizedBox(
+                                  width: double.infinity,
+                                  child: FilledButton.icon(
+                                    onPressed: _showRemoveVolumeDialog,
+                                    icon: const Icon(Icons.delete_outline),
+                                    label: const Text('Remove this volume'),
+                                    style: FilledButton.styleFrom(
+                                      backgroundColor: Theme.of(
+                                        context,
+                                      ).colorScheme.error,
+                                      foregroundColor: Theme.of(
+                                        context,
+                                      ).colorScheme.onError,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        // Access Control Card
+                        Card(
+                          elevation: 2,
+                          child: Padding(
+                            padding: const EdgeInsets.all(20),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  children: [
+                                    Icon(
+                                      Icons.visibility,
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.primary,
+                                      size: 24,
+                                    ),
+                                    const SizedBox(width: 12),
+                                    Text(
+                                      'Access control',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleMedium
+                                          ?.copyWith(
+                                            fontWeight: FontWeight.w600,
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 20),
+                                Row(
+                                  children: [
+                                    Expanded(
+                                      child: Text(
+                                        'Ownership',
+                                        style: Theme.of(
+                                          context,
+                                        ).textTheme.bodyMedium,
+                                      ),
+                                    ),
+                                    Row(
+                                      children: [
+                                        Text(
+                                          volume
+                                                      .portainer
+                                                      ?.resourceControl
+                                                      .public ==
+                                                  true
+                                              ? 'public'
+                                              : 'administrators',
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodyMedium
+                                              ?.copyWith(
+                                                fontWeight: FontWeight.w500,
+                                              ),
+                                        ),
+                                        const SizedBox(width: 8),
+                                        Icon(
+                                          Icons.info_outline,
+                                          size: 16,
+                                          color: Theme.of(
+                                            context,
+                                          ).colorScheme.onSurfaceVariant,
+                                        ),
+                                      ],
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 20),
+                                SizedBox(
+                                  width: double.infinity,
+                                  child: OutlinedButton.icon(
+                                    onPressed: _showChangeOwnershipDialog,
+                                    icon: const Icon(Icons.edit_note_outlined),
+                                    label: const Text('Change ownership'),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildDetailRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            flex: 2,
+            child: Text(
+              '$label:',
+              style: Theme.of(
+                context,
+              ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500),
+            ),
+          ),
+          Expanded(
+            flex: 3,
+            child: Text(
+              value,
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.right,
+              overflow: TextOverflow.ellipsis,
+              maxLines: 3,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/volume/widgets/volumes_screen.dart
+++ b/lib/ui/volume/widgets/volumes_screen.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:container_monitoring/ui/volume/view_models/volume_viewmodel.dart';
+import 'package:container_monitoring/domain/models/volume/volume.dart' as volume_model;
+
+class VolumesScreen extends StatefulWidget {
+  final VolumeViewmodel viewModel;
+  final int environmentId;
+
+  const VolumesScreen({
+    super.key,
+    required this.viewModel,
+    required this.environmentId,
+  });
+
+  @override
+  State<VolumesScreen> createState() => _VolumesScreenState();
+}
+
+class _VolumesScreenState extends State<VolumesScreen> {
+  final TextEditingController _nameController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _showAddVolumeDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Add Volume'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  labelText: 'Volume Name',
+                  hintText: 'Enter volume name',
+                  border: OutlineInputBorder(),
+                ),
+                autofocus: true,
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                _nameController.clear();
+              },
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () {
+                // TODO: Implement volume creation logic
+                Navigator.of(context).pop();
+                _nameController.clear();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Volume creation not implemented yet'),
+                  ),
+                );
+              },
+              child: const Text('Create'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _onVolumeTap(volume_model.Volume volume) {
+    context.push('/dashboard/${widget.environmentId}/volumes/${volume.name}');
+  }
+
+  String _formatDate(String dateString) {
+    try {
+      final date = DateTime.parse(dateString);
+      return '${date.day}/${date.month}/${date.year}';
+    } catch (e) {
+      return dateString;
+    }
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Volumes'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: _showAddVolumeDialog,
+            tooltip: 'Add Volume',
+          ),
+        ],
+      ),
+      body: ListenableBuilder(
+        listenable: widget.viewModel,
+        builder: (context, child) {
+          if (widget.viewModel.isLoading && widget.viewModel.volumes.isEmpty) {
+            return const Center(
+              child: CircularProgressIndicator(),
+            );
+          }
+
+          if (widget.viewModel.volumes.isEmpty) {
+            return const Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.storage,
+                    size: 64,
+                    color: Colors.grey,
+                  ),
+                  SizedBox(height: 16),
+                  Text(
+                    'No volumes found',
+                    style: TextStyle(
+                      fontSize: 18,
+                      color: Colors.grey,
+                    ),
+                  ),
+                  SizedBox(height: 8),
+                  Text(
+                    'Tap the + button to add a volume',
+                    style: TextStyle(
+                      color: Colors.grey,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return RefreshIndicator(
+            onRefresh: () async {
+              widget.viewModel.refreshVolumes();
+            },
+            child: ListView.builder(
+              itemCount: widget.viewModel.volumes.length,
+              itemBuilder: (context, index) {
+                final volume = widget.viewModel.volumes[index];
+                return Card(
+                  margin: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 4,
+                  ),
+                  child: ListTile(
+                    leading: CircleAvatar(
+                      backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+                      child: Icon(
+                        Icons.storage,
+                        color: Theme.of(context).colorScheme.onPrimaryContainer,
+                      ),
+                    ),
+                    title: Text(
+                      volume.name,
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        fontWeight: FontWeight.normal,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                    ),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (volume.stack != null && volume.stack!.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.layers,
+                                  size: 16,
+                                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  'Stack: ${volume.stack}',
+                                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Row(
+                            children: [
+                              Icon(
+                                Icons.access_time,
+                                size: 16,
+                                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                              ),
+                              const SizedBox(width: 4),
+                              Text(
+                                'Created: ${_formatDate(volume.createdAt)}',
+                                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                    trailing: Icon(
+                      Icons.chevron_right,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                    onTap: () => _onVolumeTap(volume),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/utils/command.dart
+++ b/lib/utils/command.dart
@@ -10,6 +10,7 @@ import 'result.dart';
 
 typedef CommandAction0<T> = Future<Result<T>> Function();
 typedef CommandAction1<T, A> = Future<Result<T>> Function(A);
+typedef CommandAction2<T, A, B> = Future<Result<T>> Function(A, B);
 
 /// Facilitates interaction with a ViewModel.
 ///
@@ -93,5 +94,16 @@ class Command1<T, A> extends Command<T> {
   /// Executes the action with the argument.
   Future<void> execute(A argument) async {
     await _execute(() => _action(argument));
+  }
+}
+
+class Command2<T, A, B> extends Command<T> {
+  Command2(this._action);
+
+  final CommandAction2<T, A, B> _action;
+
+  /// Executes the action with the arguments.
+  Future<void> execute(A argument, B argument2) async {
+    await _execute(() => _action(argument, argument2));
   }
 }


### PR DESCRIPTION
This pull request introduces support for managing Docker volumes in the application. It adds the necessary data models, repositories, API client methods, and UI routing to enable listing and viewing details of volumes associated with a specific environment. The changes are grouped into backend/data layer additions, API client enhancements, and UI/routing updates.

**Backend/Data Layer:**

* Added `VolumeRepository` and its remote implementation `VolumeRepositoryRemote`, which provide methods for listing volumes by environment and fetching a volume by name. These use new domain and API models for volumes and related Portainer info. [[1]](diffhunk://#diff-094013831e464ea1695ca9d9cee09f9a01cbc40456084b6e36e568f760921589R1-R9) [[2]](diffhunk://#diff-c0f54f754e9649312bcb416f6ee171d3f22b700aeea9badacc36c64f5a646bf9R1-R89)
* Introduced new data models for volumes (`Volume`, `PortainerInfo`, `ResourceControlInfo`) in both the domain and API layers, with serialization support via Freezed and JSON Serializable. [[1]](diffhunk://#diff-27df135e7524b876420340a51ea35f54e3e058a3e2a2dc014c2e0e92e5603ea8R1-R53) [[2]](diffhunk://#diff-acc5d54b7f5c63489947c2161bafb464e50846a466b213c7421926e4d696f084R1-R53) [[3]](diffhunk://#diff-bb0eed01c3fc7b5398edddeebd00c54cef93c55504f37a5f0908b383bcaa1750R1-R74) [[4]](diffhunk://#diff-17d3184f9437bbc18479945a3cce62df4ccb56c2d3fdb7fe288973b4fde71832R1-R76)
* Registered the new repository and models in the dependency injection setup (`dependencies.dart`). [[1]](diffhunk://#diff-51b73d02b0c8d559c89f955c673d27d225425a281862c9d357be6dd66010ef3dR13-R17) [[2]](diffhunk://#diff-51b73d02b0c8d559c89f955c673d27d225425a281862c9d357be6dd66010ef3dL46-R53)

**API Client Enhancements:**

* Added `listVolumesByEnvironment` and `getVolumeByName` methods to the `ApiClient` for retrieving volumes from the backend, including parsing and error handling. [[1]](diffhunk://#diff-aa920cd02f8a8284b25593feb51ddfd971c61376c4c887d296aed7a54ab55f5eR6) [[2]](diffhunk://#diff-aa920cd02f8a8284b25593feb51ddfd971c61376c4c887d296aed7a54ab55f5eR166-R223)

**UI and Routing:**

* Updated routing to provide navigation to a volumes list and individual volume details under each environment dashboard, wiring up the new view models and screens. [[1]](diffhunk://#diff-1920e8c585d86a5f0faf1137313d7c83e8f89e5fd728d24639b08489468543acR7-R9) [[2]](diffhunk://#diff-1920e8c585d86a5f0faf1137313d7c83e8f89e5fd728d24639b08489468543acR66-R106) [[3]](diffhunk://#diff-7d2b057861403147555bf143b6596627b13a5753b6eaf0924032e55a5248be5dR5)
* Minor update to the dashboard app bar title for consistency.

These changes lay the groundwork for full Docker volume management in the app, including data retrieval, modeling, and navigation.

---

**Backend/Data Layer:**
- Added `VolumeRepository` interface and `VolumeRepositoryRemote` implementation for listing and retrieving volumes, with integration into dependency injection. [[1]](diffhunk://#diff-094013831e464ea1695ca9d9cee09f9a01cbc40456084b6e36e568f760921589R1-R9) [[2]](diffhunk://#diff-c0f54f754e9649312bcb416f6ee171d3f22b700aeea9badacc36c64f5a646bf9R1-R89) [[3]](diffhunk://#diff-51b73d02b0c8d559c89f955c673d27d225425a281862c9d357be6dd66010ef3dR13-R17) [[4]](diffhunk://#diff-51b73d02b0c8d559c89f955c673d27d225425a281862c9d357be6dd66010ef3dL46-R53)
- Introduced new domain and API models for volumes and related Portainer information, including serialization logic. [[1]](diffhunk://#diff-27df135e7524b876420340a51ea35f54e3e058a3e2a2dc014c2e0e92e5603ea8R1-R53) [[2]](diffhunk://#diff-acc5d54b7f5c63489947c2161bafb464e50846a466b213c7421926e4d696f084R1-R53) [[3]](diffhunk://#diff-bb0eed01c3fc7b5398edddeebd00c54cef93c55504f37a5f0908b383bcaa1750R1-R74) [[4]](diffhunk://#diff-17d3184f9437bbc18479945a3cce62df4ccb56c2d3fdb7fe288973b4fde71832R1-R76)

**API Client Enhancements:**
- Implemented `listVolumesByEnvironment` and `getVolumeByName` methods in `ApiClient` for backend communication and response parsing. [[1]](diffhunk://#diff-aa920cd02f8a8284b25593feb51ddfd971c61376c4c887d296aed7a54ab55f5eR6) [[2]](diffhunk://#diff-aa920cd02f8a8284b25593feb51ddfd971c61376c4c887d296aed7a54ab55f5eR166-R223)

**UI and Routing:**
- Added routes and view model wiring for volumes list and volume detail screens under the dashboard route. [[1]](diffhunk://#diff-1920e8c585d86a5f0faf1137313d7c83e8f89e5fd728d24639b08489468543acR7-R9) [[2]](diffhunk://#diff-1920e8c585d86a5f0faf1137313d7c83e8f89e5fd728d24639b08489468543acR66-R106) [[3]](diffhunk://#diff-7d2b057861403147555bf143b6596627b13a5753b6eaf0924032e55a5248be5dR5)
- Updated dashboard screen to use a static title for consistency.